### PR TITLE
Set correct macro for static symbols

### DIFF
--- a/pkgconfig/oapv.pc.in
+++ b/pkgconfig/oapv.pc.in
@@ -2,7 +2,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@ 
 exec_prefix=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_BINDIR@
 libdir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@
-includedir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@/@LIB_NAME@
+includedir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@/@LIB_NAME_BASE@
 
 Name: oapv
 Description: Advanced Professional Video Codec
@@ -10,6 +10,8 @@ Description: Advanced Professional Video Codec
 Version: @PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@.@PROJECT_VERSION_PATCH@
 
 Requires:
-Libs: -L${libdir} -loapv
+Libs: -L${libdir} -l@LIB_NAME_BASE@
+Libs.private: -L${libdir}/@LIB_NAME_BASE@ -lm
 
 Cflags: -I${includedir}
+Cflags.private: -DOAPV_STATIC_DEFINE

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,7 +64,7 @@ generate_export_header(${LIB_NAME_BASE}_dynamic
                        EXPORT_FILE_NAME ${CMAKE_BINARY_DIR}/include/oapv/oapv_exports.h)
 
 # This will cause the export macros to expand to nothing when building the static library.
-set_target_properties(${LIB_NAME_BASE} PROPERTIES COMPILE_FLAGS -DLIBSHARED_AND_STATIC_STATIC_DEFINE)
+target_compile_definitions(${LIB_NAME_BASE} PUBLIC OAPV_STATIC_DEFINE)
 
 source_group("base\\header" FILES ${LIB_BASE_INC} ${LIB_INC})
 source_group("base\\source" FILES ${LIB_BASE_SRC} ${LIB_API_SRC})


### PR DESCRIPTION
Not sure if I interpreted this correctly, but LIBSHARED_AND_STATIC_STATIC_DEFINE does not appear anywhere else in the codebase, but OAPV_STATIC_DEFINE is used instead.

This flag also needs to be set in the pkgconfig file for private Cflags. Plus, the static library is installed into a subdir of the libdir, so that needs to be set in there, too.