### PR TITLE
Skip y4m test on non-seekable input

### DIFF
--- a/app/oapv_app_y4m.h
+++ b/app/oapv_app_y4m.h
@@ -45,6 +45,11 @@ static int y4m_test(FILE *fp)
 
     char buffer[9] = { 0 };
 
+    if (ftell(fp) < 0) {
+        /* Not seekable, so probably a pipe: assume not-y4m. */
+        return 0;
+    }
+
     /*Peek to check if y4m header is present*/
     if(!fread(buffer, 1, 8, fp))
         return -1;


### PR DESCRIPTION
On a non-seekable input such as a pipe this check skips the first eight bytes which silently corrupts the stream.

This fixes the use-case of piping input from another program because some preprocessing or conversion is needed, such as with ffmpeg:
```
 ffmpeg -i input.mp4 -vf scale=1280:720,format=yuv422p10 -f rawvideo - | bin/oapv_app_enc -i /dev/stdin -w 1280 -h 720 --input-csp 2 -d 10 -z 60 --profile 422-10 --band 3 -o out.apv
```