### PR TITLE
Delete unused variable

### DIFF
--- a/src/oapv.c
+++ b/src/oapv.c
@@ -2065,7 +2065,6 @@ int oapvd_info(void *au, int au_size, oapv_au_info_t *aui)
 {
     int ret, frm_count = 0;
     u32 cur_read_size = 0;
-    int pbu_count = 0;
     oapv_bs_t bs;
 
     DUMP_SET(0);
@@ -2122,7 +2121,6 @@ int oapvd_info(void *au, int au_size, oapv_au_info_t *aui)
         }
         aui->num_frms = frm_count;
         cur_read_size += pbu_size + 4; /* 4byte is for pbu_size syntax itself */
-        pbu_count++;
     } while(cur_read_size < au_size);
     DUMP_SET(1);
     return OAPV_OK;


### PR DESCRIPTION
- To avoid compile warning, delete pbu_count in oapvd_info().


```
/Users/yearlykim/Applications/CLion.app/Contents/bin/cmake/mac/aarch64/bin/cmake --build /Users/yearlykim/Documents/project/openapv_external/cmake-build-release --target oapv_app_enc -j 12
[13/15] Building C object src/CMakeFiles/oapv.dir/oapv.c.o
/Users/yearlykim/Documents/project/openapv_external/src/oapv.c:2068:9: warning: variable 'pbu_count' set but not used [-Wunused-but-set-variable]
 2068 |     int pbu_count = 0;
      |         ^
1 warning generated.
```