### PR TITLE
Skip y4m test on non-seekable input

### DIFF
--- a/app/oapv_app_y4m.h
+++ b/app/oapv_app_y4m.h
@@ -45,6 +45,11 @@ static int y4m_test(FILE *fp)
 
     char buffer[9] = { 0 };
 
+    if (ftell(fp) < 0) {
+        /* Not seekable, so probably a pipe: assume not-y4m. */
+        return 0;
+    }
+
     /*Peek to check if y4m header is present*/
     if(!fread(buffer, 1, 8, fp))
         return -1;


### PR DESCRIPTION
On a non-seekable input such as a pipe this check skips the first eight bytes which silently corrupts the stream.

Reopen of https://github.com/AcademySoftwareFoundation/openapv/pull/79 because I can't reopen the original after amending.