### PR TITLE
added disable_raw_bitstream_format

### DIFF
--- a/inc/oapv.h
+++ b/inc/oapv.h
@@ -532,7 +532,6 @@ struct oapve_param {
     int           full_range_flag;
 };
 
-#define OAPV_CDESC_THREADS_AUTO          0
 /*****************************************************************************
  * automatic assignment of number of threads in creation of encoder & decoder
  *****************************************************************************/
@@ -549,6 +548,8 @@ struct oapve_cdesc {
     int           max_num_frms;
     // max number of threads (or OAPV_CDESC_THREADS_AUTO for auto-assignment)
     int           threads;
+    // flag to disable 'raw bitstream format'
+    int           disable_raw_bitstream_format;
     // encoding parameters
     oapve_param_t param[OAPV_MAX_NUM_FRAMES];
 };

--- a/src/oapv_param.c
+++ b/src/oapv_param.c
@@ -62,7 +62,6 @@ int oapve_param_default(oapve_param_t *param)
     param->transfer_characteristics = 2; // unspecified transfer characteristics
     param->matrix_coefficients = 2; // unspecified matrix coefficients
     param->full_range_flag = 0; // limited range
-
     return OAPV_OK;
 }
 


### PR DESCRIPTION
Supports encoding output which doesn't have 'au_size' of 'raw bitstream format'.
It can be controlled by the 'disable_raw_bitstream_format' variable in oapve_cdesc_t structure.