### PR TITLE
Add config to disable raw bitstream format

### DIFF
--- a/inc/oapv.h
+++ b/inc/oapv.h
@@ -152,6 +152,7 @@ extern "C" {
 #define OAPV_CFG_SET_QP_MIN             (208)
 #define OAPV_CFG_SET_QP_MAX             (209)
 #define OAPV_CFG_SET_USE_FRM_HASH       (301)
+#define OAPV_CFG_SET_AU_BS_FMT          (302)
 #define OAPV_CFG_GET_QP_MIN             (600)
 #define OAPV_CFG_GET_QP_MAX             (601)
 #define OAPV_CFG_GET_QP                 (602)
@@ -161,6 +162,16 @@ extern "C" {
 #define OAPV_CFG_GET_FPS_DEN            (606)
 #define OAPV_CFG_GET_WIDTH              (701)
 #define OAPV_CFG_GET_HEIGHT             (702)
+#define OAPV_CFG_GET_AU_BS_FMT          (802)
+
+/*****************************************************************************
+ * config values
+ *****************************************************************************/
+/* The output from the encoder is compliant with raw_bitstream_access_unit */
+#define OAPV_CFG_VAL_AU_BS_FMT_RBAU     (0)
+/* The output from the encoder consists of access units that are not preceded
+   by an access unit size */
+#define OAPV_CFG_VAL_AU_BS_FMT_NONE     (1)
 
 /*****************************************************************************
  * HLS configs

--- a/inc/oapv.h
+++ b/inc/oapv.h
@@ -169,8 +169,7 @@ extern "C" {
  *****************************************************************************/
 /* The output from the encoder is compliant with raw_bitstream_access_unit */
 #define OAPV_CFG_VAL_AU_BS_FMT_RBAU     (0)
-/* The output from the encoder consists of access units that are not preceded
-   by an access unit size */
+/* The output from the encoder is the only AU without bitstream format */
 #define OAPV_CFG_VAL_AU_BS_FMT_NONE     (1)
 
 /*****************************************************************************

--- a/src/oapv.c
+++ b/src/oapv.c
@@ -751,7 +751,7 @@ static int enc_ready(oapve_ctx_t *ctx)
 
     ctx->rc_param.alpha = OAPV_RC_ALPHA;
     ctx->rc_param.beta = OAPV_RC_BETA;
-    ctx->au_bs_format = OAPV_CFG_VAL_AU_BS_FMT_RBAU; // default: enable raw bitstream format
+    ctx->au_bs_fmt = OAPV_CFG_VAL_AU_BS_FMT_RBAU; // default: enable raw bitstream format
 
     return OAPV_OK;
 ERR:
@@ -1307,7 +1307,7 @@ int oapve_encode(oapve_t eid, oapv_frms_t *ifrms, oapvm_t mid, oapv_bitb_t *bitb
 
     bs_pos_au_beg = oapv_bsw_sink(bs);
 
-    if(ctx->au_bs_format == OAPV_CFG_VAL_AU_BS_FMT_RBAU) {
+    if(ctx->au_bs_fmt == OAPV_CFG_VAL_AU_BS_FMT_RBAU) {
         oapv_bsw_write(bs, 0, 32); // raw bitstream byte size (skip)
     }
     oapv_bsw_write(bs, 0x61507631, 32); // signature ('aPv1')
@@ -1384,7 +1384,7 @@ int oapve_encode(oapve_t eid, oapv_frms_t *ifrms, oapvm_t mid, oapv_bitb_t *bitb
         }
     }
 
-    if(ctx->au_bs_format == OAPV_CFG_VAL_AU_BS_FMT_RBAU) {
+    if(ctx->au_bs_fmt == OAPV_CFG_VAL_AU_BS_FMT_RBAU) {
         u32 au_size = (u32)((u8 *)oapv_bsw_sink(bs) - bs_pos_au_beg) - 4;
         oapv_bsw_write_direct(bs_pos_au_beg, au_size, 32);
     }
@@ -1438,7 +1438,7 @@ int oapve_config(oapve_t eid, int cfg, void *buf, int *size)
         oapv_assert_rv(*size == sizeof(int), OAPV_ERR_INVALID_ARGUMENT);
         t0 = *((int *)buf);
         oapv_assert_rv(t0 == OAPV_CFG_VAL_AU_BS_FMT_RBAU || t0 == OAPV_CFG_VAL_AU_BS_FMT_NONE, OAPV_ERR_INVALID_ARGUMENT);
-        ctx->au_bs_format = t0;
+        ctx->au_bs_fmt = t0;
         break;
     /* get config *******************************************************/
     case OAPV_CFG_GET_QP:
@@ -1467,7 +1467,7 @@ int oapve_config(oapve_t eid, int cfg, void *buf, int *size)
         break;
     case OAPV_CFG_GET_AU_BS_FMT:
         oapv_assert_rv(*size == sizeof(int), OAPV_ERR_INVALID_ARGUMENT);
-        *((int *)buf) = ctx->au_bs_format;
+        *((int *)buf) = ctx->au_bs_fmt;
         break;
     default:
         oapv_trace("unknown config value (%d)\n", cfg);

--- a/src/oapv.c
+++ b/src/oapv.c
@@ -751,6 +751,7 @@ static int enc_ready(oapve_ctx_t *ctx)
 
     ctx->rc_param.alpha = OAPV_RC_ALPHA;
     ctx->rc_param.beta = OAPV_RC_BETA;
+    ctx->au_bs_format = OAPV_CFG_VAL_AU_BS_FMT_RBAU; // default: enable raw bitstream format
 
     return OAPV_OK;
 ERR:
@@ -1292,8 +1293,9 @@ int oapve_encode(oapve_t eid, oapv_frms_t *ifrms, oapvm_t mid, oapv_bitb_t *bitb
 {
     oapve_ctx_t *ctx;
     oapv_frm_t  *frm;
-    oapv_bs_t   *bs;
+    oapv_bs_t   *bs, bs_pbu_beg;
     int          i, ret;
+    u8          *bs_pos_pbu_beg, *bs_pos_au_beg;
 
     ctx = enc_id_to_ctx(eid);
     oapv_assert_rv(ctx != NULL && bitb->addr && bitb->bsize > 0, OAPV_ERR_INVALID_ARGUMENT);
@@ -1303,11 +1305,11 @@ int oapve_encode(oapve_t eid, oapv_frms_t *ifrms, oapvm_t mid, oapv_bitb_t *bitb
     oapv_bsw_init(bs, bitb->addr, bitb->bsize, NULL);
     oapv_mset(stat, 0, sizeof(oapve_stat_t));
 
-    u8       *bs_pos_au_beg = oapv_bsw_sink(bs); // address syntax of au size
-    u8       *bs_pos_pbu_beg;
-    oapv_bs_t bs_pbu_beg;
-    oapv_bsw_write(bs, 0, 32); // raw bitstream byte size (skip)
+    bs_pos_au_beg = oapv_bsw_sink(bs);
 
+    if(ctx->au_bs_format == OAPV_CFG_VAL_AU_BS_FMT_RBAU) {
+        oapv_bsw_write(bs, 0, 32); // raw bitstream byte size (skip)
+    }
     oapv_bsw_write(bs, 0x61507631, 32); // signature ('aPv1')
 
     for(i = 0; i < ifrms->num_frms; i++) {
@@ -1318,7 +1320,7 @@ int oapve_encode(oapve_t eid, oapv_frms_t *ifrms, oapvm_t mid, oapv_bitb_t *bitb
         ret = enc_read_param(ctx, ctx->param);
         oapv_assert_rv(ret == OAPV_OK, ret);
 
-        oapv_assert_rv(ctx->param->profile_idc == OAPV_PROFILE_422_10 || ctx->param->profile_idc == OAPV_PROFILE_400_10, OAPV_ERR_UNSUPPORTED);
+        oapv_assert_rv(ctx->param->profile_idc == OAPV_PROFILE_422_10, OAPV_ERR_UNSUPPORTED);
 
         // prepare for encoding a frame
         ret = enc_frm_prepare(ctx, frm->imgb, (rfrms != NULL) ? rfrms->frm[i].imgb : NULL);
@@ -1382,8 +1384,10 @@ int oapve_encode(oapve_t eid, oapv_frms_t *ifrms, oapvm_t mid, oapv_bitb_t *bitb
         }
     }
 
-    u32 au_size = (u32)((u8 *)oapv_bsw_sink(bs) - bs_pos_au_beg) - 4 /* au_size */;
-    oapv_bsw_write_direct(bs_pos_au_beg, au_size, 32); /* u(32) */
+    if(ctx->au_bs_format == OAPV_CFG_VAL_AU_BS_FMT_RBAU) {
+        u32 au_size = (u32)((u8 *)oapv_bsw_sink(bs) - bs_pos_au_beg) - 4;
+        oapv_bsw_write_direct(bs_pos_au_beg, au_size, 32);
+    }
 
     oapv_bsw_deinit(&ctx->bs); /* de-init BSW */
     stat->write = bsw_get_write_byte(&ctx->bs);
@@ -1430,6 +1434,12 @@ int oapve_config(oapve_t eid, int cfg, void *buf, int *size)
         oapv_assert_rv(*size == sizeof(int), OAPV_ERR_INVALID_ARGUMENT);
         ctx->use_frm_hash = (*((int *)buf)) ? 1 : 0;
         break;
+    case OAPV_CFG_SET_AU_BS_FMT:
+        oapv_assert_rv(*size == sizeof(int), OAPV_ERR_INVALID_ARGUMENT);
+        t0 = *((int *)buf);
+        oapv_assert_rv(t0 == OAPV_CFG_VAL_AU_BS_FMT_RBAU || t0 == OAPV_CFG_VAL_AU_BS_FMT_NONE, OAPV_ERR_INVALID_ARGUMENT);
+        ctx->au_bs_format = t0;
+        break;
     /* get config *******************************************************/
     case OAPV_CFG_GET_QP:
         oapv_assert_rv(*size == sizeof(int), OAPV_ERR_INVALID_ARGUMENT);
@@ -1454,6 +1464,10 @@ int oapve_config(oapve_t eid, int cfg, void *buf, int *size)
     case OAPV_CFG_GET_BPS:
         oapv_assert_rv(*size == sizeof(int), OAPV_ERR_INVALID_ARGUMENT);
         *((int *)buf) = ctx->param->bitrate;
+        break;
+    case OAPV_CFG_GET_AU_BS_FMT:
+        oapv_assert_rv(*size == sizeof(int), OAPV_ERR_INVALID_ARGUMENT);
+        *((int *)buf) = ctx->au_bs_format;
         break;
     default:
         oapv_trace("unknown config value (%d)\n", cfg);

--- a/src/oapv_def.h
+++ b/src/oapv_def.h
@@ -311,6 +311,7 @@ struct oapve_ctx {
     oapve_rc_param_t          rc_param;
 
     int                       threads; // num of thread for encoding
+    int                       au_bs_format; // access unit bitstream format
     /* platform specific data, if needed */
     void                     *pf;
 };

--- a/src/oapv_def.h
+++ b/src/oapv_def.h
@@ -311,7 +311,7 @@ struct oapve_ctx {
     oapve_rc_param_t          rc_param;
 
     int                       threads; // num of thread for encoding
-    int                       au_bs_format; // access unit bitstream format
+    int                       au_bs_fmt; // access unit bitstream format
     /* platform specific data, if needed */
     void                     *pf;
 };


### PR DESCRIPTION
+ Added config value for disabling 'RAW bitstream format'
The following code will disable raw bitstream format.
```
    int val = OAPV_CFG_VAL_AU_BS_FMT_NONE;
    int size = sizeof(val);
    oapve_config(id, OAPV_CFG_SET_AU_BS_FMT, &val, &size);
```