### PR TITLE
Restrict odd width

### DIFF
--- a/inc/oapv.h
+++ b/inc/oapv.h
@@ -85,8 +85,9 @@ extern "C" {
 #define OAPV_ERR_MALFORMED_BITSTREAM    (-202)
 #define OAPV_ERR_OUT_OF_BS_BUF          (-203) /* too small bitstream buffer */
 #define OAPV_ERR_NOT_FOUND              (-204)
-#define OAPV_ERR_FAILED_SYSCALL         (-301)   /* failed system call */
+#define OAPV_ERR_FAILED_SYSCALL         (-301) /* failed system call */
 #define OAPV_ERR_INVALID_LEVEL          (-401)
+#define OAPV_ERR_INVALID_WIDTH          (-405) /* invalid width (like odd) */
 #define OAPV_ERR_UNKNOWN                (-32767) /* unknown error */
 
 /* return value checking */

--- a/src/oapv_param.c
+++ b/src/oapv_param.c
@@ -476,6 +476,9 @@ int oapve_param_update(oapve_ctx_t* ctx)
     int ret = OAPV_OK;
     int min_num_tiles = OAPV_MAX_TILES;
     for (int i = 0; i < ctx->cdesc.max_num_frms; i++) {
+        if(ctx->cdesc.param[i].w & 0x1) { // check width restriction
+            return OAPV_ERR_INVALID_WIDTH; // odd width is not spec-out
+        }
         ret = enc_update_param_tile(ctx, &ctx->cdesc.param[i]);
         oapv_assert_rv(ret == OAPV_OK, ret);
         int num_tiles = oapv_div_round_up(ctx->w, ctx->cdesc.param[i].tile_w) * oapv_div_round_up(ctx->h, ctx->cdesc.param[i].tile_h);

--- a/src/oapv_param.c
+++ b/src/oapv_param.c
@@ -476,7 +476,7 @@ int oapve_param_update(oapve_ctx_t* ctx)
     int ret = OAPV_OK;
     int min_num_tiles = OAPV_MAX_TILES;
     for (int i = 0; i < ctx->cdesc.max_num_frms; i++) {
-        if(ctx->cdesc.param[i].w & 0x1) { // check width restriction
+        if(ctx->cdesc.param[i].csp == 2 && ctx->cdesc.param[i].w & 0x1) { // check width restriction for 422
             return OAPV_ERR_INVALID_WIDTH; // odd width is not spec-out
         }
         ret = enc_update_param_tile(ctx, &ctx->cdesc.param[i]);

--- a/src/oapv_vlc.c
+++ b/src/oapv_vlc.c
@@ -702,7 +702,7 @@ int oapvd_vlc_frame_info(oapv_bs_t *bs, oapv_fi_t *fi)
     // check frame width in case of 422 format.
     if(fi->chroma_format_idc == 2) {
         // frame_width should be multiple of 2
-        oapv_assert_rv((fi->frame_width & 0x1) == 0, OAPV_ERR_MALFORMED_BITSTREAM);
+        oapv_assert_rv((fi->frame_width & 0x1) == 0, OAPV_ERR_INVALID_WIDTH);
     }
 
     return OAPV_OK;


### PR DESCRIPTION
+ In case of 422 color sampling, odd width value returns error in encoder and decoder