### PR TITLE
Fix definition of OAPV_STATIC_DEFINE in the pkg-config for static only builds

### DIFF
--- a/pkgconfig/oapv.pc.in
+++ b/pkgconfig/oapv.pc.in
@@ -13,5 +13,5 @@ Requires:
 Libs: -L${libdir} -l@LIB_NAME_BASE@
 Libs.private: -L${libdir}/@LIB_NAME_BASE@ -lm
 
-Cflags: -I${includedir}
-Cflags.private: -DOAPV_STATIC_DEFINE
+Cflags: -I${includedir} @EXTRA_CFLAGS@
+Cflags.private: @EXTRA_CFLAGS_PRIVATE@

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -173,6 +173,13 @@ if(OAPV_BUILD_SHARED_LIB)
 endif()
 
 if(NOT MSVC)
+    if(OAPV_BUILD_SHARED_LIB)
+        set(EXTRA_CFLAGS "")
+        set(EXTRA_CFLAGS_PRIVATE "-DOAPV_STATIC_DEFINE")
+    else()
+        set(EXTRA_CFLAGS "-DOAPV_STATIC_DEFINE")
+        set(EXTRA_CFLAGS_PRIVATE "")
+    endif()
     configure_file(
       "${CMAKE_SOURCE_DIR}/pkgconfig/${LIB_NAME_BASE}.pc.in"
       "${CMAKE_BINARY_DIR}/${LIB_NAME_BASE}.pc" @ONLY)


### PR DESCRIPTION
The check in oapv.h will fail otherwise on builds with no shared libs, as oapv_exports.h is not installed and OAPV_STATIC_DEFINE will be defined only if pkg-config is invoked with --static.