### PR TITLE
improved oapv_version() again

### DIFF
--- a/app/oapv_app_dec.c
+++ b/app/oapv_app_dec.c
@@ -377,11 +377,8 @@ int main(int argc, const char **argv)
     memset(&ofrms, 0, sizeof(oapv_frms_t));
 
     // print logo
-    char version[16];
-    oapv_version(version, sizeof(version));
-
     logv2("  ____                ___   ___ _   __\n");
-    logv2(" / __ \\___  ___ ___  / _ | / _ \\ | / / Decoder (v%s)\n", version);
+    logv2(" / __ \\___  ___ ___  / _ | / _ \\ | / / Decoder (v%s)\n", oapv_version(NULL));
     logv2("/ /_/ / _ \\/ -_) _ \\/ __ |/ ___/ |/ / \n");
     logv2("\\____/ .__/\\__/_//_/_/ |_/_/   |___/  \n");
     logv2("    /_/                               \n");

--- a/app/oapv_app_enc.c
+++ b/app/oapv_app_enc.c
@@ -598,11 +598,8 @@ int main(int argc, const char **argv)
     const int      num_frames = MAX_NUM_FRMS; // number of frames in an access unit
 
     // print logo
-    char version[16];
-    oapv_version(version, sizeof(version));
-
     logv2("  ____                ___   ___ _   __\n");
-    logv2(" / __ \\___  ___ ___  / _ | / _ \\ | / / Encoder (v%s)\n", version);
+    logv2(" / __ \\___  ___ ___  / _ | / _ \\ | / / Encoder (v%s)\n", oapv_version(NULL));
     logv2("/ /_/ / _ \\/ -_) _ \\/ __ |/ ___/ |/ / \n");
     logv2("\\____/ .__/\\__/_//_/_/ |_/_/   |___/  \n");
     logv2("    /_/                               \n");

--- a/inc/oapv.h
+++ b/inc/oapv.h
@@ -680,8 +680,7 @@ OAPV_EXPORT int oapvd_info(void *au, int au_size, oapv_au_info_t *aui);
 /*****************************************************************************
  * openapv version
  *****************************************************************************/
-OAPV_EXPORT unsigned int oapv_version(char *ver, int size);
-
+OAPV_EXPORT const char *oapv_version(unsigned int *ver_num);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/oapv.c
+++ b/src/oapv.c
@@ -2153,15 +2153,14 @@ int oapvd_info(void *au, int au_size, oapv_au_info_t *aui)
 #endif // ENABLE_DECODER
 ///////////////////////////////////////////////////////////////////////////////
 
-unsigned int oapv_version(char *ver, int size)
+const char *oapv_version(unsigned int *ver_num)
 {
-    if(ver != NULL) {
-        int written = snprintf(ver, size, "%d.%d.%d.%d",
-            OAPV_VER_APISET, OAPV_VER_MAJOR, OAPV_VER_MINOR, OAPV_VER_PATCH);
-        // check if snprintf encountered an error or if the output was truncated.
-        if (written < 0 || written >= size) {
-            return OAPV_ERR_INVALID_ARGUMENT;
-        }
-    }
-    return OAPV_VER_NUM;
+    static char oapv_version_string[16];
+    snprintf(oapv_version_string, sizeof(oapv_version_string), "%d.%d.%d.%d",
+        OAPV_VER_APISET, OAPV_VER_MAJOR, OAPV_VER_MINOR, OAPV_VER_PATCH);
+
+    if(ver_num != NULL)
+        *ver_num = OAPV_VER_NUM;
+
+    return (char*)oapv_version_string;
 }


### PR DESCRIPTION
+ change opav_version() prototype to avoid the mixed meaning of return value.