### PR TITLE
Copy metadata data in apv library

### DIFF
--- a/inc/oapv.h
+++ b/inc/oapv.h
@@ -631,9 +631,9 @@ typedef struct oapvm_payload oapvm_payload_t;
 struct oapvm_payload {
     int           group_id;  // group ID
     int           type;      // payload type
-    unsigned char uuid[16];  // UUID for user-defined metadata payload
+    int           size;      // byte size of metadata payload
     void         *data;      // address of metadata payload
-    int           data_size; // byte size of metadata payload
+    unsigned char uuid[16];  // UUID for user-defined metadata payload
 };
 
 /*****************************************************************************
@@ -643,12 +643,12 @@ typedef void       *oapvm_t; // instance identifier for OAPV metadata container
 
 OAPV_EXPORT oapvm_t oapvm_create(int *err);
 OAPV_EXPORT void oapvm_delete(oapvm_t mid);
-OAPV_EXPORT void oapvm_rem_all(oapvm_t mid);
 OAPV_EXPORT int oapvm_set(oapvm_t mid, int group_id, int type, void *data, int size);
 OAPV_EXPORT int oapvm_get(oapvm_t mid, int group_id, int type, void **data, int *size, unsigned char *uuid);
 OAPV_EXPORT int oapvm_rem(oapvm_t mid, int group_id, int type, unsigned char *uuid);
 OAPV_EXPORT int oapvm_set_all(oapvm_t mid, oapvm_payload_t *pld, int num_plds);
 OAPV_EXPORT int oapvm_get_all(oapvm_t mid, oapvm_payload_t *pld, int *num_plds);
+OAPV_EXPORT void oapvm_rem_all(oapvm_t mid);
 
 /*****************************************************************************
  * interface for encoder

--- a/inc/oapv.h
+++ b/inc/oapv.h
@@ -644,7 +644,7 @@ typedef void       *oapvm_t; // instance identifier for OAPV metadata container
 OAPV_EXPORT oapvm_t oapvm_create(int *err);
 OAPV_EXPORT void oapvm_delete(oapvm_t mid);
 OAPV_EXPORT void oapvm_rem_all(oapvm_t mid);
-OAPV_EXPORT int oapvm_set(oapvm_t mid, int group_id, int type, void *data, int size, unsigned char *uuid);
+OAPV_EXPORT int oapvm_set(oapvm_t mid, int group_id, int type, void *data, int size);
 OAPV_EXPORT int oapvm_get(oapvm_t mid, int group_id, int type, void **data, int *size, unsigned char *uuid);
 OAPV_EXPORT int oapvm_rem(oapvm_t mid, int group_id, int type, unsigned char *uuid);
 OAPV_EXPORT int oapvm_set_all(oapvm_t mid, oapvm_payload_t *pld, int num_plds);

--- a/src/oapv.c
+++ b/src/oapv.c
@@ -1374,7 +1374,7 @@ int oapve_encode(oapve_t eid, oapv_frms_t *ifrms, oapvm_t mid, oapv_bitb_t *bitb
     if(md_list != NULL) {
         int num_md = md_list->num;
         for(i = 0; i < num_md; i++) {
-            int group_id = md_list->group_ids[i];
+            int group_id = md_list->md_arr[i].group_id;
             bs_pos_pbu_beg = oapv_bsw_sink(bs);            /* store pbu pos to calculate size */
             oapv_mcpy(&bs_pbu_beg, bs, sizeof(oapv_bs_t)); /* store pbu pos of ai to re-write */
             DUMP_SAVE(0);

--- a/src/oapv_metadata.c
+++ b/src/oapv_metadata.c
@@ -168,10 +168,10 @@ static void meta_free_md(oapv_md_t *md)
 {
     oapv_mdp_t *mdp = md->md_payload;
     while(mdp != NULL) {
-        oapv_mdp_t *tmp_mdp = mdp;
+        oapv_mfree(mdp->pld_data);
+        oapv_mdp_t *mdp_t = mdp;
         mdp = mdp->next;
-        oapv_mfree(tmp_mdp->pld_data);
-        oapv_mfree(tmp_mdp);
+        oapv_mfree(mdp_t);
     }
 }
 

--- a/src/oapv_metadata.c
+++ b/src/oapv_metadata.c
@@ -57,107 +57,10 @@ static inline u32 meta_get_byte_pld_all(oapv_mdp_t *mdp)
     return meta_get_byte_pld_type(mdp) + meta_get_byte_pld_size(mdp) + mdp->pld_size;
 }
 
-static oapv_mdp_t **meta_mdp_find_last_with_check(oapv_md_t *md, int type, unsigned char *uuid)
-{
-    oapv_mdp_t **last_mdp = &md->md_payload;
-
-    while((*last_mdp) != NULL) {
-        if((*last_mdp) == NULL)
-            break;
-        if((*last_mdp)->pld_type == type) {
-            if(type == OAPV_METADATA_USER_DEFINED) {
-                if(oapv_mcmp(uuid, (*last_mdp)->pld_data, 16) == 0) {
-                    return NULL;
-                }
-            }
-            else {
-                return NULL;
-            }
-        }
-        last_mdp = &((*last_mdp)->next);
-    }
-    return last_mdp;
-}
-
-static oapv_mdp_t *meta_md_find_mdp(oapv_md_t *md, int mdt)
+static oapv_mdp_t *meta_mdp_find_ud(oapv_md_t *md, unsigned char *uuid, oapv_mdp_t **prev_mdp)
 {
     oapv_mdp_t *mdp = md->md_payload;
-
-    while(mdp != NULL) {
-        if(mdp->pld_type == mdt) {
-            break;
-        }
-        mdp = mdp->next;
-    }
-
-    return mdp;
-}
-
-static int meta_free_mdp_data(oapv_mdp_t *mdp)
-{
-    oapv_mfree(mdp->pld_data);
-    mdp->pld_data = NULL;
-    return OAPV_OK;
-}
-
-static int meta_md_rm_mdp(oapv_md_t *md, int mdt)
-{
-    oapv_mdp_t *mdp = md->md_payload;
-    oapv_mdp_t *mdp_prev = NULL;
-
-    while(mdp->pld_type != mdt && mdp->next != NULL) {
-        mdp_prev = mdp;
-        mdp = mdp->next;
-    }
-
-    if(mdp->pld_type == mdt) {
-        if(mdp_prev == NULL) {
-            md->md_payload = mdp->next;
-        }
-        else {
-            mdp_prev->next = mdp->next;
-        }
-        meta_free_mdp_data(mdp);
-        md->md_size -= meta_get_byte_pld_all(mdp);
-        oapv_mfree(mdp);
-        md->md_num--;
-        return OAPV_OK;
-    }
-
-    return OAPV_ERR_NOT_FOUND;
-}
-
-static int meta_md_rm_usd(oapv_md_t *md, unsigned char *uuid)
-{
-    oapv_mdp_t *mdp = md->md_payload;
-    oapv_mdp_t *mdp_prev = NULL;
-    while(mdp != NULL) {
-        if(mdp->pld_type == OAPV_METADATA_USER_DEFINED) {
-            if(oapv_mcmp(uuid, mdp->pld_data, 16) == 0) {
-                if(mdp_prev == NULL) {
-                    md->md_payload = mdp->next;
-                }
-                else {
-                    mdp_prev->next = mdp->next;
-                }
-                oapv_assert_rv(md->md_size >= mdp->pld_size, OAPV_ERR_UNEXPECTED);
-                meta_free_mdp_data(mdp);
-                md->md_size -= meta_get_byte_pld_all(mdp);
-                oapv_mfree(mdp);
-                md->md_num--;
-                return OAPV_OK;
-            }
-        }
-        mdp_prev = mdp;
-        mdp = mdp->next;
-    }
-
-    return OAPV_ERR_NOT_FOUND;
-}
-
-static oapv_mdp_t *meta_md_find_usd(oapv_md_t *md, unsigned char *uuid)
-{
-    oapv_mdp_t *mdp = md->md_payload;
+    *prev_mdp = NULL;
     while(mdp != NULL) {
         if(mdp->pld_type == OAPV_METADATA_USER_DEFINED) {
             oapv_md_usd_t *usd = (oapv_md_usd_t *)mdp->pld_data;
@@ -165,39 +68,94 @@ static oapv_mdp_t *meta_md_find_usd(oapv_md_t *md, unsigned char *uuid)
                 return mdp;
             }
         }
+        *prev_mdp = mdp;
         mdp = mdp->next;
     }
 
     return NULL;
 }
 
+static oapv_mdp_t *meta_mdp_find_non_ud(oapv_md_t *md, int mdt, oapv_mdp_t **prev_mdp)
+{
+    oapv_mdp_t *mdp = md->md_payload;
+    *prev_mdp = NULL;
+    while(mdp != NULL) {
+        if(mdp->pld_type == mdt) {
+            break;
+        }
+        *prev_mdp = mdp;
+        mdp = mdp->next;
+    }
+
+    return mdp;
+}
+static oapv_mdp_t *meta_md_find_mdp(oapv_md_t *md, int type, unsigned char *uuid)
+{
+    oapv_mdp_t *prev_mdp;
+    return (type == OAPV_METADATA_USER_DEFINED) ? meta_mdp_find_ud(md, uuid, &prev_mdp) : meta_mdp_find_non_ud(md, type, &prev_mdp);
+}
+
+static oapv_mdp_t *meta_md_find_mdp_with_prev(oapv_md_t *md, int type, unsigned char *uuid, oapv_mdp_t **prev_mdp)
+{
+    return (type == OAPV_METADATA_USER_DEFINED) ? meta_mdp_find_ud(md, uuid, prev_mdp) : meta_mdp_find_non_ud(md, type, prev_mdp);
+}
+
+static int meta_rm_mdp(oapv_md_t *md, int mdt, unsigned char *uuid)
+{
+    oapv_mdp_t *mdp, *mdp_prev;
+    mdp = meta_md_find_mdp_with_prev(md, mdt, uuid, &mdp_prev);
+    oapv_assert_rv(mdp != NULL, OAPV_ERR_NOT_FOUND);
+    if(mdp_prev == NULL) {
+        md->md_payload = mdp->next;
+    }
+    else {
+        mdp_prev->next = mdp->next;
+    }
+
+    oapv_assert_rv(md->md_size >= mdp->pld_size, OAPV_ERR_UNEXPECTED);
+    md->md_size -= meta_get_byte_pld_all(mdp);
+    oapv_mfree(mdp->pld_data);
+    oapv_mfree(mdp);
+    md->mdp_num--;
+    return OAPV_OK;
+}
+
+static oapv_md_t *meta_find_md(oapvm_ctx_t *ctx, int group_id)
+{
+    for(int n = 0; n < ctx->num; n++) {
+        if(group_id == ctx->md_arr[n].group_id) {
+            return &ctx->md_arr[n];
+        }
+    }
+    return NULL;
+}
 
 
 static int meta_verify_mdp_data(int type, int size, u8 *data)
 {
     if(type == OAPV_METADATA_ITU_T_T35) {
         if(size == 0) {
-            return OAPV_ERR_INVALID_ARGUMENT;
+            return OAPV_ERR_MALFORMED_BITSTREAM;
         }
         if(*data == 0xFF) {
             if(size == 1) {
-                return OAPV_ERR_INVALID_ARGUMENT;
+                return OAPV_ERR_MALFORMED_BITSTREAM;
             }
         }
     }
     else if(type == OAPV_METADATA_MDCV) {
         if(size != 24) {
-            return OAPV_ERR_INVALID_ARGUMENT;
+            return OAPV_ERR_MALFORMED_BITSTREAM;
         }
     }
     else if(type == OAPV_METADATA_CLL) {
         if(size != 4) {
-            return OAPV_ERR_INVALID_ARGUMENT;
+            return OAPV_ERR_MALFORMED_BITSTREAM;
         }
     }
     else if(type == OAPV_METADATA_USER_DEFINED) {
         if(size < 16) {
-            return OAPV_ERR_INVALID_ARGUMENT;
+            return OAPV_ERR_MALFORMED_BITSTREAM;
         }
     }
     else {
@@ -212,143 +170,101 @@ static void meta_free_md(oapv_md_t *md)
     while(mdp != NULL) {
         oapv_mdp_t *tmp_mdp = mdp;
         mdp = mdp->next;
-        meta_free_mdp_data(tmp_mdp);
+        oapv_mfree(tmp_mdp->pld_data);
         oapv_mfree(tmp_mdp);
     }
 }
 
 int oapvm_set(oapvm_t mid, int group_id, int type, void *data, int size, unsigned char *uuid)
 {
-    oapvm_ctx_t *md_list = meta_id_to_ctx(mid);
-    oapv_assert_rv(md_list, OAPV_ERR_INVALID_ARGUMENT);
-    int          ret = meta_verify_mdp_data(type, size, (u8 *)data);
+    void        *pld_data_new = NULL;
+    oapv_mdp_t  *mdp_new = NULL; 
+    int          ret = OAPV_OK;
+    oapvm_ctx_t *ctx = meta_id_to_ctx(mid);
+    oapv_assert_rv(ctx, OAPV_ERR_NOT_FOUND);
+    
+    ret = meta_verify_mdp_data(type, size, (u8 *)data);
     oapv_assert_rv(OAPV_SUCCEEDED(ret), ret);
-    void *tmp_mdp_data = NULL;
-    if(data != NULL && size > 0) {
-        tmp_mdp_data = oapv_malloc(size);
-        oapv_assert_rv(tmp_mdp_data != NULL, OAPV_ERR_OUT_OF_MEMORY);
-        oapv_mcpy(tmp_mdp_data, data, size);
+
+    oapv_md_t *cur_md = meta_find_md(ctx, group_id);
+    if(cur_md == NULL) {
+        oapv_assert_rv(ctx->num < OAPV_MAX_NUM_METAS, OAPV_ERR_REACHED_MAX);
+        cur_md = &ctx->md_arr[ctx->num++];
+        cur_md->group_id = group_id;
+        cur_md->md_size = 0;
+        cur_md->mdp_num = 0;
+        cur_md->md_payload = NULL;
     }
 
-    int md_list_idx = 0;
-    while(md_list_idx < md_list->num) {
-        if(md_list->group_ids[md_list_idx] == group_id) {
-            break;
-        }
-        md_list_idx++;
+    if(data != NULL && size > 0) {
+        pld_data_new = oapv_malloc(size);
+        oapv_assert_rv(pld_data_new != NULL, OAPV_ERR_OUT_OF_MEMORY);
+        oapv_mcpy(pld_data_new, data, size);
     }
-    if(md_list_idx == md_list->num) {
-        md_list->num++;
+    oapv_mdp_t  *mdp_t = meta_md_find_mdp(cur_md, type, uuid);
+    if(mdp_t != NULL) { // replace the exist one
+        cur_md->md_size -= meta_get_byte_pld_all(mdp_t);
+        mdp_t->pld_size = size;
+        oapv_mfree(mdp_t->pld_data);
+        mdp_t->pld_data = pld_data_new;
+        cur_md->md_size += meta_get_byte_pld_all(mdp_t);
     }
-    md_list->group_ids[md_list_idx] = group_id;
-    oapv_mdp_t **last_ptr = meta_mdp_find_last_with_check(&md_list->md_arr[md_list_idx], type,
-                                                          (type == OAPV_METADATA_USER_DEFINED) ? uuid : NULL);
-    while(last_ptr == NULL) {
-        oapvm_rem(mid, group_id, type, uuid);
-        last_ptr = meta_mdp_find_last_with_check(&md_list->md_arr[md_list_idx], type,
-                                                 (type == OAPV_METADATA_USER_DEFINED) ? uuid : NULL);
+    else { // add new one
+        mdp_new = oapv_malloc(sizeof(oapv_mdp_t));
+        oapv_assert_gv(mdp_new != NULL, ret, OAPV_ERR_OUT_OF_MEMORY, ERR);
+        mdp_new->pld_size = size;
+        mdp_new->pld_type = type;
+        mdp_new->pld_data = pld_data_new;
+        mdp_new->next = cur_md->md_payload; // add to head
+        cur_md->md_payload = mdp_new;
+        cur_md->mdp_num++;
+        cur_md->md_size += meta_get_byte_pld_all(mdp_new);
     }
-    oapv_mdp_t *tmp_mdp = oapv_malloc(sizeof(oapv_mdp_t));
-    if(tmp_mdp == NULL) {
-        if(size > 0) {
-            oapv_mfree(tmp_mdp_data);
-        }
-        return OAPV_ERR_OUT_OF_MEMORY;
-    }
-    tmp_mdp->pld_size = size;
-    tmp_mdp->pld_type = type;
-    tmp_mdp->pld_data = tmp_mdp_data;
-    tmp_mdp->next = NULL;
-    *last_ptr = tmp_mdp;
-    md_list->md_arr[md_list_idx].md_size += meta_get_byte_pld_all(tmp_mdp);
-    md_list->md_arr[md_list_idx].md_num++;
     return OAPV_OK;
+    
+ERR:
+    if(pld_data_new)
+        oapv_mfree(pld_data_new);
+    return ret;
 }
 
 int oapvm_get(oapvm_t mid, int group_id, int type, void **data, int *size, unsigned char *uuid)
 {
-    oapvm_ctx_t *md_list = meta_id_to_ctx(mid);
-    for(int i = 0; i < md_list->num; i++) {
-        if(group_id != md_list->group_ids[i]) {
-            continue;
-        }
-        oapv_mdp_t *mdp = (type == OAPV_METADATA_USER_DEFINED) ? meta_md_find_usd(&md_list->md_arr[i], uuid) : meta_md_find_mdp(&md_list->md_arr[i], type);
-        if(mdp != NULL) {
-            *data = mdp->pld_data;
-            *size = mdp->pld_size;
-            return OAPV_OK;
-        }
-    }
+    oapvm_ctx_t *ctx = meta_id_to_ctx(mid);
+    oapv_assert_g(ctx != NULL, ERR);
+    oapv_md_t   *md = meta_find_md(ctx, group_id);
+    oapv_assert_g(md != NULL, ERR);
+    oapv_mdp_t *mdp = meta_md_find_mdp(md, type, uuid);
+    oapv_assert_g(mdp != NULL, ERR);
+    
+    *data = mdp->pld_data;
+    *size = mdp->pld_size;
 
+    return OAPV_OK;
+
+ERR:
     return OAPV_ERR_NOT_FOUND;
 }
+
 int oapvm_rem(oapvm_t mid, int group_id, int type, unsigned char *uuid)
 {
-    oapvm_ctx_t *md_list = meta_id_to_ctx(mid);
-    int          md_list_idx = 0;
-    while(md_list_idx < md_list->num) {
-        if(md_list->group_ids[md_list_idx] == group_id) {
-            break;
-        }
-        md_list_idx++;
-    }
-    oapv_assert_rv(md_list_idx < md_list->num, OAPV_ERR_NOT_FOUND);
-    if(type == OAPV_METADATA_USER_DEFINED) {
-        return meta_md_rm_usd(&md_list->md_arr[md_list_idx], uuid);
-    }
-    return meta_md_rm_mdp(&md_list->md_arr[md_list_idx], type);
+    oapvm_ctx_t *ctx = meta_id_to_ctx(mid);
+    oapv_assert_g(ctx != NULL, ERR);
+    oapv_md_t   *md = meta_find_md(ctx, group_id);
+    oapv_assert_g(md != NULL, ERR);
+    return meta_rm_mdp(md, type, uuid);
+
+ERR:
+    return OAPV_ERR_NOT_FOUND;
+
 }
 
 int oapvm_set_all(oapvm_t mid, oapvm_payload_t *pld, int num_plds)
 {
     int          ret;
-    oapvm_ctx_t *md_list = meta_id_to_ctx(mid);
     for(int i = 0; i < num_plds; i++) {
-        ret = meta_verify_mdp_data(pld[i].type, pld[i].data_size, (u8 *)pld[i].data);
+        ret = oapvm_set(mid, pld[i].group_id, pld[i].type, pld[i].data, pld[i].data_size, pld[i].uuid);
         oapv_assert_g(OAPV_SUCCEEDED(ret), ERR);
-
-        int md_list_idx = 0;
-        while(md_list_idx < md_list->num) {
-            if(md_list->group_ids[md_list_idx] == pld[i].group_id) {
-                break;
-            }
-            md_list_idx++;
-        }
-        if(md_list_idx == md_list->num) {
-            md_list->num++;
-        }
-
-        md_list->group_ids[md_list_idx] = pld[i].group_id;
-        md_list->md_arr[md_list_idx].md_num++;
-        oapv_mdp_t **last_ptr = meta_mdp_find_last_with_check(&md_list->md_arr[md_list_idx], pld[i].type,
-                                                              (pld[i].type == OAPV_METADATA_USER_DEFINED) ? pld[i].uuid : NULL);
-        while(last_ptr == NULL) {
-            oapvm_rem(mid, pld[i].group_id, pld[i].type, pld[i].uuid);
-            last_ptr = meta_mdp_find_last_with_check(&md_list->md_arr[md_list_idx], pld[i].type,
-                                                     (pld[i].type == OAPV_METADATA_USER_DEFINED) ? pld[i].uuid : NULL);
-        }
-        void *tmp_mdp_data = NULL;
-        if(pld[i].data != NULL && pld[i].data_size > 0) {
-            tmp_mdp_data = oapv_malloc(pld[i].data_size);
-            oapv_assert_rv(tmp_mdp_data != NULL, OAPV_ERR_OUT_OF_MEMORY);
-            oapv_mcpy(tmp_mdp_data, pld[i].data, pld[i].data_size);
-        }
-
-        oapv_mdp_t *tmp_mdp = oapv_malloc(sizeof(oapv_mdp_t));
-        if(tmp_mdp == NULL) {
-            if(pld[i].data_size > 0) {
-                oapv_mfree(tmp_mdp_data);
-            }
-            return OAPV_ERR_OUT_OF_MEMORY;
-        }
-        oapv_assert_rv(tmp_mdp != NULL, OAPV_ERR_OUT_OF_MEMORY);
-        tmp_mdp->pld_size = pld[i].data_size;
-        tmp_mdp->pld_type = pld[i].type;
-        tmp_mdp->pld_data = tmp_mdp_data;
-        tmp_mdp->next = NULL;
-        md_list->md_arr[md_list_idx].md_size += meta_get_byte_pld_all(tmp_mdp);
-
-        *last_ptr = tmp_mdp;
     }
     return OAPV_OK;
 
@@ -356,38 +272,38 @@ ERR:
     return ret;
 }
 
+
 int oapvm_get_all(oapvm_t mid, oapvm_payload_t *pld, int *num_plds)
 {
-    oapvm_ctx_t *md_list = meta_id_to_ctx(mid);
+    oapvm_ctx_t *ctx = meta_id_to_ctx(mid);
+    oapv_assert_rv(ctx != NULL, OAPV_ERR_NOT_FOUND);
     if(pld == NULL) {
         int num_payload = 0;
-        for(int i = 0; i < md_list->num; i++) {
-            num_payload += md_list->md_arr[i].md_num;
+        for(int i = 0; i < ctx->num; i++) {
+            num_payload += ctx->md_arr[i].mdp_num;
         }
         *num_plds = num_payload;
         return OAPV_OK;
     }
-    int p_cnt = 0;
-    for(int i = 0; i < md_list->num; i++) {
-        int         group_id = md_list->group_ids[i];
-        oapv_mdp_t *mdp = md_list->md_arr[i].md_payload;
+    int pld_cnt = 0;
+    for(int i = 0; i < ctx->num; i++) {
+        oapv_md_t  *cur_md = &ctx->md_arr[i];
+        int         group_id = cur_md->group_id;
+        oapv_mdp_t *mdp = cur_md->md_payload;
         while(mdp != NULL) {
-            oapv_assert_rv(p_cnt < *num_plds, OAPV_ERR_REACHED_MAX);
-            pld[p_cnt].group_id = group_id;
-            pld[p_cnt].data_size = mdp->pld_size;
-            pld[p_cnt].data = mdp->pld_data;
-            pld[p_cnt].type = mdp->pld_type;
-            if(pld[p_cnt].type == OAPV_METADATA_USER_DEFINED) {
-                oapv_mcpy(pld[p_cnt].uuid, mdp->pld_data, 16);
+            oapv_assert_rv(pld_cnt < *num_plds, OAPV_ERR_REACHED_MAX);
+            pld[pld_cnt].group_id = group_id;
+            pld[pld_cnt].data_size = mdp->pld_size;
+            pld[pld_cnt].data = mdp->pld_data;
+            pld[pld_cnt].type = mdp->pld_type;
+            if(pld[pld_cnt].type == OAPV_METADATA_USER_DEFINED) {
+                oapv_mcpy(pld[pld_cnt].uuid, mdp->pld_data, 16);
             }
-            else {
-                oapv_mset(pld[p_cnt].uuid, 0, 16);
-            }
-            p_cnt++;
+            pld_cnt++;
             mdp = mdp->next;
         }
     }
-    *num_plds = p_cnt;
+    *num_plds = pld_cnt;
     return OAPV_OK;
 }
 
@@ -398,7 +314,6 @@ void oapvm_rem_all(oapvm_t mid)
     for(int i = 0; i < md_list->num; i++) {
         meta_free_md(&md_list->md_arr[i]);
         oapv_mset(&md_list->md_arr[i], 0, sizeof(oapv_md_t));
-        md_list->group_ids[i] = 0;
     }
     md_list->num = 0;
 }

--- a/src/oapv_metadata.c
+++ b/src/oapv_metadata.c
@@ -173,11 +173,12 @@ static void meta_free_md(oapv_md_t *md)
     }
 }
 
-int oapvm_set(oapvm_t mid, int group_id, int type, void *data, int size, unsigned char *uuid)
+int oapvm_set(oapvm_t mid, int group_id, int type, void *data, int size)
 {
     void        *pld_data_new = NULL;
     oapv_mdp_t  *mdp_new = NULL;
     int          ret = OAPV_OK;
+    u8          *uuid = NULL;
 
     oapvm_ctx_t *ctx = meta_id_to_ctx(mid);
     oapv_assert_rv(ctx, OAPV_ERR_INVALID_ARGUMENT);
@@ -185,6 +186,10 @@ int oapvm_set(oapvm_t mid, int group_id, int type, void *data, int size, unsigne
 
     ret = meta_verify_mdp_data(type, size, (u8 *)data);
     oapv_assert_rv(OAPV_SUCCEEDED(ret), ret);
+
+    if(type == OAPV_METADATA_USER_DEFINED){
+        uuid = (u8 *)data;
+    }
 
     if(size > 0) {
         pld_data_new = oapv_malloc(size);
@@ -267,7 +272,7 @@ int oapvm_set_all(oapvm_t mid, oapvm_payload_t *pld, int num_plds)
 {
     int          ret;
     for(int i = 0; i < num_plds; i++) {
-        ret = oapvm_set(mid, pld[i].group_id, pld[i].type, pld[i].data, pld[i].data_size, pld[i].uuid);
+        ret = oapvm_set(mid, pld[i].group_id, pld[i].type, pld[i].data, pld[i].data_size);
         oapv_assert_g(OAPV_SUCCEEDED(ret), ERR);
     }
     return OAPV_OK;

--- a/src/oapv_metadata.c
+++ b/src/oapv_metadata.c
@@ -252,7 +252,9 @@ int oapvm_set(oapvm_t mid, int group_id, int type, void *data, int size, unsigne
     }
     oapv_mdp_t *tmp_mdp = oapv_malloc(sizeof(oapv_mdp_t));
     if(tmp_mdp == NULL) {
-        oapv_mfree(tmp_mdp_data);
+        if(size > 0) {
+            oapv_mfree(tmp_mdp_data);
+        }
         return OAPV_ERR_OUT_OF_MEMORY;
     }
     oapv_mset(tmp_mdp, 0, sizeof(oapv_mdp_t));
@@ -336,7 +338,9 @@ int oapvm_set_all(oapvm_t mid, oapvm_payload_t *pld, int num_plds)
 
         oapv_mdp_t *tmp_mdp = oapv_malloc(sizeof(oapv_mdp_t));
         if(tmp_mdp == NULL) {
-            oapv_mfree(tmp_mdp_data);
+            if(pld[i].data_size > 0) {
+                oapv_mfree(tmp_mdp_data);
+            }
             return OAPV_ERR_OUT_OF_MEMORY;
         }
         oapv_assert_rv(tmp_mdp != NULL, OAPV_ERR_OUT_OF_MEMORY);

--- a/src/oapv_metadata.c
+++ b/src/oapv_metadata.c
@@ -95,10 +95,8 @@ static oapv_mdp_t *meta_md_find_mdp(oapv_md_t *md, int mdt)
 
 static int meta_free_mdp_data(oapv_mdp_t *mdp)
 {
-    if(mdp->pld_size > 0) {
-        oapv_mfree(mdp->pld_data);
-        mdp->pld_data = NULL;
-    }
+    oapv_mfree(mdp->pld_data);
+    mdp->pld_data = NULL;
     return OAPV_OK;
 }
 
@@ -257,10 +255,10 @@ int oapvm_set(oapvm_t mid, int group_id, int type, void *data, int size, unsigne
         }
         return OAPV_ERR_OUT_OF_MEMORY;
     }
-    oapv_mset(tmp_mdp, 0, sizeof(oapv_mdp_t));
     tmp_mdp->pld_size = size;
     tmp_mdp->pld_type = type;
     tmp_mdp->pld_data = tmp_mdp_data;
+    tmp_mdp->next = NULL;
     *last_ptr = tmp_mdp;
     md_list->md_arr[md_list_idx].md_size += meta_get_byte_pld_all(tmp_mdp);
     md_list->md_arr[md_list_idx].md_num++;
@@ -344,10 +342,10 @@ int oapvm_set_all(oapvm_t mid, oapvm_payload_t *pld, int num_plds)
             return OAPV_ERR_OUT_OF_MEMORY;
         }
         oapv_assert_rv(tmp_mdp != NULL, OAPV_ERR_OUT_OF_MEMORY);
-        oapv_mset(tmp_mdp, 0, sizeof(oapv_mdp_t));
         tmp_mdp->pld_size = pld[i].data_size;
         tmp_mdp->pld_type = pld[i].type;
         tmp_mdp->pld_data = tmp_mdp_data;
+        tmp_mdp->next = NULL;
         md_list->md_arr[md_list_idx].md_size += meta_get_byte_pld_all(tmp_mdp);
 
         *last_ptr = tmp_mdp;

--- a/src/oapv_metadata.c
+++ b/src/oapv_metadata.c
@@ -272,7 +272,7 @@ int oapvm_set_all(oapvm_t mid, oapvm_payload_t *pld, int num_plds)
 {
     int          ret;
     for(int i = 0; i < num_plds; i++) {
-        ret = oapvm_set(mid, pld[i].group_id, pld[i].type, pld[i].data, pld[i].data_size);
+        ret = oapvm_set(mid, pld[i].group_id, pld[i].type, pld[i].data, pld[i].size);
         oapv_assert_g(OAPV_SUCCEEDED(ret), ERR);
     }
     return OAPV_OK;
@@ -302,7 +302,7 @@ int oapvm_get_all(oapvm_t mid, oapvm_payload_t *pld, int *num_plds)
         while(mdp != NULL) {
             oapv_assert_rv(pld_cnt < *num_plds, OAPV_ERR_REACHED_MAX);
             pld[pld_cnt].group_id = group_id;
-            pld[pld_cnt].data_size = mdp->pld_size;
+            pld[pld_cnt].size = mdp->pld_size;
             pld[pld_cnt].data = mdp->pld_data;
             pld[pld_cnt].type = mdp->pld_type;
             if(pld[pld_cnt].type == OAPV_METADATA_USER_DEFINED) {

--- a/src/oapv_metadata.h
+++ b/src/oapv_metadata.h
@@ -48,7 +48,8 @@ struct oapv_mdp {
 
 typedef struct oapv_md oapv_md_t;
 struct oapv_md {
-    int         md_num;
+    int         mdp_num;
+    int         group_id;
     u32         md_size; /* u(32) */
     oapv_mdp_t *md_payload;
 };
@@ -57,7 +58,6 @@ typedef struct oapvm_ctx oapvm_ctx_t;
 struct oapvm_ctx {
     u32       magic; // magic code
     oapv_md_t md_arr[OAPV_MAX_NUM_METAS];
-    int       group_ids[OAPV_MAX_NUM_METAS];
     int       num;
 };
 

--- a/src/oapv_metadata.h
+++ b/src/oapv_metadata.h
@@ -40,8 +40,8 @@
 /* Metadata payload */
 typedef struct oapv_mdp oapv_mdp_t;
 struct oapv_mdp {
-    u32         pld_type; /* u(8) */
-    u32         pld_size; /* u(8) */
+    u32         pld_type; /* u(32) */
+    u32         pld_size; /* u(32) */
     void       *pld_data;
     oapv_mdp_t *next;
 };

--- a/src/oapv_metadata.h
+++ b/src/oapv_metadata.h
@@ -50,7 +50,6 @@ typedef struct oapv_md oapv_md_t;
 struct oapv_md {
     int         mdp_num;
     int         group_id;
-    u32         md_size; /* u(32) */
     oapv_mdp_t *md_payload;
 };
 

--- a/src/oapv_util.c
+++ b/src/oapv_util.c
@@ -286,7 +286,10 @@ int oapv_set_md5_pld(oapvm_t mid, int group_id, oapv_imgb_t *rec)
     for(int i = 0; i < rec->np; i++) {
         memcpy(mdp_data + ((i + 1) * 16), rec->hash[i], 16);
     }
-    return oapvm_set(mid, group_id, OAPV_METADATA_USER_DEFINED, mdp_data, 16 * rec->np + 16, uuid_frm_hash);
+    int ret = oapvm_set(mid, group_id, OAPV_METADATA_USER_DEFINED, mdp_data, 16 * rec->np + 16, uuid_frm_hash);
+    oapv_assert_rv(OAPV_SUCCEEDED(ret), ret);
+    oapv_mfree(mdp_data);
+    return OAPV_OK;
 }
 
 void oapv_block_copy(s16 *src, int src_stride, s16 *dst, int dst_stride, int log2_copy_w, int log2_copy_h)

--- a/src/oapv_util.c
+++ b/src/oapv_util.c
@@ -281,12 +281,12 @@ int oapv_set_md5_pld(oapvm_t mid, int group_id, oapv_imgb_t *rec)
 {
     oapv_imgb_set_md5(rec);
     u8 *mdp_data = oapv_malloc((16 * rec->np) + 16);
-    oapv_assert_rv(mdp_data != NULL, OAPV_ERR_OUT_OF_MEMORY)
-        memcpy(mdp_data, uuid_frm_hash, 16);
+    oapv_assert_rv(mdp_data != NULL, OAPV_ERR_OUT_OF_MEMORY);
+    memcpy(mdp_data, uuid_frm_hash, 16);
     for(int i = 0; i < rec->np; i++) {
         memcpy(mdp_data + ((i + 1) * 16), rec->hash[i], 16);
     }
-    int ret = oapvm_set(mid, group_id, OAPV_METADATA_USER_DEFINED, mdp_data, 16 * rec->np + 16, uuid_frm_hash);
+    int ret = oapvm_set(mid, group_id, OAPV_METADATA_USER_DEFINED, mdp_data, 16 * rec->np + 16);
     oapv_assert_rv(OAPV_SUCCEEDED(ret), ret);
     oapv_mfree(mdp_data);
     return OAPV_OK;

--- a/src/oapv_vlc.c
+++ b/src/oapv_vlc.c
@@ -1353,22 +1353,21 @@ int oapvd_vlc_metadata(oapv_bs_t *bs, u32 pbu_size, oapvm_t mid, int group_id)
         oapv_assert_gv(payload_size <= metadata_size, ret, OAPV_ERR_MALFORMED_BITSTREAM, ERR);
 
         if(payload_size > 0) {
-
-            payload_data = oapv_malloc(payload_size);
-            oapv_assert_gv(payload_data != NULL, ret, OAPV_ERR_OUT_OF_MEMORY, ERR);
+            oapv_bsr_sink(bs);
+            payload_data = bs->cur;
+            
+            
             if(payload_type == OAPV_METADATA_FILLER) {
                 for(u32 i = 0; i < payload_size; i++) {
                     t0 = oapv_bsr_read(bs, 8);
                     DUMP_HLS(payload_data, t0);
                     oapv_assert_gv(t0 == 0xFF, ret, OAPV_ERR_MALFORMED_BITSTREAM, ERR);
-                    payload_data[i] = 0xFF;
                 }
             }
             else {
                 for(u32 i = 0; i < payload_size; i++) {
                     t0 = oapv_bsr_read(bs, 8);
                     DUMP_HLS(payload_data, t0);
-                    payload_data[i] = t0;
                 }
             }
         }

--- a/src/oapv_vlc.c
+++ b/src/oapv_vlc.c
@@ -1369,6 +1369,9 @@ int oapvd_vlc_metadata(oapv_bs_t *bs, u32 pbu_size, oapvm_t mid, int group_id)
                 }
             }
         }
+        else {
+            payload_data = NULL;
+        }
         ret = oapvm_set(mid, group_id, payload_type, payload_data, payload_size,
                         payload_type == OAPV_METADATA_USER_DEFINED ? payload_data : NULL);
         oapv_assert_g(OAPV_SUCCEEDED(ret), ERR);

--- a/src/oapv_vlc.c
+++ b/src/oapv_vlc.c
@@ -575,8 +575,11 @@ int oapve_vlc_pbu_header(oapv_bs_t *bs, int pbu_type, int group_id)
 /****** ENABLE_DECODER ******/
 int oapve_vlc_metadata(oapv_md_t *md, oapv_bs_t *bs)
 {
-    oapv_bsw_write(bs, md->md_size, 32);
-    DUMP_HLS(metadata_size, md->md_size);
+    u8 *bs_pos_md;
+    bs_pos_md = oapv_bsw_sink(bs);
+    
+    oapv_bsw_write(bs, 0, 32); // raw bitstream byte size (skip)
+
     oapv_mdp_t *mdp = md->md_payload;
 
     while(mdp != NULL) {
@@ -606,6 +609,10 @@ int oapve_vlc_metadata(oapv_md_t *md, oapv_bs_t *bs)
 
         mdp = mdp->next;
     }
+    u32 md_size = (u32)((u8 *)oapv_bsw_sink(bs) - bs_pos_md) - 4;
+    oapv_bsw_write_direct(bs_pos_md, md_size, 32);
+    DUMP_HLS(metadata_size, md_size);
+ 
     return OAPV_OK;
 }
 
@@ -1353,20 +1360,25 @@ int oapvd_vlc_metadata(oapv_bs_t *bs, u32 pbu_size, oapvm_t mid, int group_id)
         oapv_assert_gv(payload_size <= metadata_size, ret, OAPV_ERR_MALFORMED_BITSTREAM, ERR);
 
         if(payload_size > 0) {
-            oapv_bsr_sink(bs);
-            payload_data = bs->cur;
+            oapv_assert_gv(BSR_GET_LEFT_BYTE(bs) >= payload_size, ret, OAPV_ERR_MALFORMED_BITSTREAM, ERR);
+            payload_data = oapv_bsr_sink(bs);
+  
             if(payload_type == OAPV_METADATA_FILLER) {
-                for(u32 i = 0; i < payload_size; i++) {
+                for(int i = 0; i < payload_size; i++) {
                     t0 = oapv_bsr_read(bs, 8);
                     DUMP_HLS(payload_data, t0);
                     oapv_assert_gv(t0 == 0xFF, ret, OAPV_ERR_MALFORMED_BITSTREAM, ERR);
                 }
             }
             else {
-                for(u32 i = 0; i < payload_size; i++) {
+#if ENC_DEC_DUMP
+                for(int i = 0; i < payload_size; i++) {
                     t0 = oapv_bsr_read(bs, 8);
                     DUMP_HLS(payload_data, t0);
                 }
+#else
+                BSR_MOVE_BYTE_ALIGN(bs, payload_size);
+#endif
             }
         }
         else {

--- a/src/oapv_vlc.c
+++ b/src/oapv_vlc.c
@@ -1355,8 +1355,6 @@ int oapvd_vlc_metadata(oapv_bs_t *bs, u32 pbu_size, oapvm_t mid, int group_id)
         if(payload_size > 0) {
             oapv_bsr_sink(bs);
             payload_data = bs->cur;
-            
-            
             if(payload_type == OAPV_METADATA_FILLER) {
                 for(u32 i = 0; i < payload_size; i++) {
                     t0 = oapv_bsr_read(bs, 8);
@@ -1382,7 +1380,6 @@ int oapvd_vlc_metadata(oapv_bs_t *bs, u32 pbu_size, oapvm_t mid, int group_id)
     return OAPV_OK;
 
 ERR:
-    // TO-DO: free memory
     return ret;
 }
 

--- a/src/oapv_vlc.c
+++ b/src/oapv_vlc.c
@@ -577,7 +577,7 @@ int oapve_vlc_metadata(oapv_md_t *md, oapv_bs_t *bs)
 {
     u8 *bs_pos_md;
     bs_pos_md = oapv_bsw_sink(bs);
-    
+
     oapv_bsw_write(bs, 0, 32); // raw bitstream byte size (skip)
 
     oapv_mdp_t *mdp = md->md_payload;
@@ -612,7 +612,7 @@ int oapve_vlc_metadata(oapv_md_t *md, oapv_bs_t *bs)
     u32 md_size = (u32)((u8 *)oapv_bsw_sink(bs) - bs_pos_md) - 4;
     oapv_bsw_write_direct(bs_pos_md, md_size, 32);
     DUMP_HLS(metadata_size, md_size);
- 
+
     return OAPV_OK;
 }
 
@@ -1362,7 +1362,7 @@ int oapvd_vlc_metadata(oapv_bs_t *bs, u32 pbu_size, oapvm_t mid, int group_id)
         if(payload_size > 0) {
             oapv_assert_gv(BSR_GET_LEFT_BYTE(bs) >= payload_size, ret, OAPV_ERR_MALFORMED_BITSTREAM, ERR);
             payload_data = oapv_bsr_sink(bs);
-  
+
             if(payload_type == OAPV_METADATA_FILLER) {
                 for(int i = 0; i < payload_size; i++) {
                     t0 = oapv_bsr_read(bs, 8);
@@ -1384,8 +1384,7 @@ int oapvd_vlc_metadata(oapv_bs_t *bs, u32 pbu_size, oapvm_t mid, int group_id)
         else {
             payload_data = NULL;
         }
-        ret = oapvm_set(mid, group_id, payload_type, payload_data, payload_size,
-                        payload_type == OAPV_METADATA_USER_DEFINED ? payload_data : NULL);
+        ret = oapvm_set(mid, group_id, payload_type, payload_data, payload_size);
         oapv_assert_g(OAPV_SUCCEEDED(ret), ERR);
         metadata_size -= payload_size;
     }


### PR DESCRIPTION
- Fix memory leak on metadata payload.
- Change metadata data to be copied by the apv library