### PR TITLE
Creating oapv_mset_x128 avx function to replace memset and improve speed

### DIFF
--- a/src/oapv_port.c
+++ b/src/oapv_port.c
@@ -121,3 +121,32 @@ int oapv_get_num_cpu_cores(void)
     return num_cores;
 }
 
+#if X86_SSE
+void *oapv_memset_x128_avx(void* dst, int value, size_t size) {
+    uint8_t* ptr = (uint8_t*)dst;
+    __m128i value_vec = _mm_set1_epi8((char)value);  // 16-byte (128-bit) vector
+
+    size_t i = 0;
+    // Store 128 units per iteration
+    for(; i + 128 < size; i += 128) {
+        _mm_store_si128((__m128i*)(ptr +   0), value_vec);
+        _mm_store_si128((__m128i*)(ptr +  16), value_vec);
+        _mm_store_si128((__m128i*)(ptr +  32), value_vec);
+        _mm_store_si128((__m128i*)(ptr +  48), value_vec);
+        _mm_store_si128((__m128i*)(ptr +  64), value_vec);
+        _mm_store_si128((__m128i*)(ptr +  80), value_vec);
+        _mm_store_si128((__m128i*)(ptr +  96), value_vec);
+        _mm_store_si128((__m128i*)(ptr + 112), value_vec);
+    }
+    // Remaining full 16-unit blocks
+    for (; i + 16 < size; i += 16) {
+        _mm_store_si128((__m128i*)(ptr+i), value_vec);
+    }
+
+    // Remaining tail
+    for (; i < size; ++i) {
+        ptr[i] = (uint8_t)value;
+    }
+    return dst;
+}
+#endif

--- a/src/oapv_port.h
+++ b/src/oapv_port.h
@@ -183,7 +183,6 @@ void oapv_mfree_align32(void *p);
 #else
 #define oapv_mset_x128(dst, v, size) memset((dst), (v), (size))
 #endif
-#define oapv_mset_x128(dst, v, size) memset((dst), (v), (size))
 #define oapv_mcmp(dst, src, size)    memcmp((dst), (src), (size))
 
 static __inline void oapv_mset_16b(s16 *dst, s16 v, int cnt)

--- a/src/oapv_port.h
+++ b/src/oapv_port.h
@@ -68,41 +68,6 @@ typedef s32      dpel;
 #endif
 
 /*****************************************************************************
- * memory operations
- *****************************************************************************/
-#define oapv_malloc(size)      malloc((size))
-#define oapv_malloc_fast(size) oapv_malloc((size))
-
-#define oapv_mfree(m) \
-    {                 \
-        if(m) {       \
-            free(m);  \
-        }             \
-    }
-#define oapv_mfree_fast(m) \
-    {                      \
-        if(m) {            \
-            oapv_mfree(m); \
-        }                  \
-    }
-
-void *oapv_malloc_align32(int size);
-void oapv_mfree_align32(void *p);
-
-#define oapv_mcpy(dst, src, size)    memcpy((dst), (src), (size))
-#define oapv_mset(dst, v, size)      memset((dst), (v), (size))
-#define oapv_mset_x64a(dst, v, size) memset((dst), (v), (size))
-#define oapv_mset_x128(dst, v, size) memset((dst), (v), (size))
-#define oapv_mcmp(dst, src, size)    memcmp((dst), (src), (size))
-
-static __inline void oapv_mset_16b(s16 *dst, s16 v, int cnt)
-{
-    int i;
-    for(i = 0; i < cnt; i++)
-        dst[i] = v;
-}
-
-/*****************************************************************************
  * trace and assert
  *****************************************************************************/
 void oapv_trace0(char *filename, int line, const char *fmt, ...);
@@ -187,6 +152,46 @@ void oapv_trace_line(char *pre);
 #if ARM_NEON
 #include <arm_neon.h>
 #endif
+
+/*****************************************************************************
+ * memory operations
+ *****************************************************************************/
+#define oapv_malloc(size)      malloc((size))
+#define oapv_malloc_fast(size) oapv_malloc((size))
+
+#define oapv_mfree(m) \
+    {                 \
+        if(m) {       \
+            free(m);  \
+        }             \
+    }
+#define oapv_mfree_fast(m) \
+    {                      \
+        if(m) {            \
+            oapv_mfree(m); \
+        }                  \
+    }
+
+void *oapv_malloc_align32(int size);
+void oapv_mfree_align32(void *p);
+
+#define oapv_mcpy(dst, src, size)    memcpy((dst), (src), (size))
+#define oapv_mset(dst, v, size)      memset((dst), (v), (size))
+#define oapv_mset_x64a(dst, v, size) memset((dst), (v), (size))
+#if X86_SSE
+#define oapv_mset_x128(dst, v, size) oapv_memset_x128_avx((dst), (v), (size))
+#else
+#define oapv_mset_x128(dst, v, size) memset((dst), (v), (size))
+#endif
+#define oapv_mset_x128(dst, v, size) memset((dst), (v), (size))
+#define oapv_mcmp(dst, src, size)    memcmp((dst), (src), (size))
+
+static __inline void oapv_mset_16b(s16 *dst, s16 v, int cnt)
+{
+    int i;
+    for(i = 0; i < cnt; i++)
+        dst[i] = v;
+}
 
 /* Buffer Alignement */
 #if defined(_WIN32) && !defined(__GNUC__)

--- a/src/oapv_port.h
+++ b/src/oapv_port.h
@@ -174,6 +174,9 @@ void oapv_trace_line(char *pre);
 
 void *oapv_malloc_align32(int size);
 void oapv_mfree_align32(void *p);
+#if X86_SSE
+void *oapv_memset_x128_avx(void* dst, int value, size_t size);
+#endif
 
 #define oapv_mcpy(dst, src, size)    memcpy((dst), (src), (size))
 #define oapv_mset(dst, v, size)      memset((dst), (v), (size))


### PR DESCRIPTION
- Created `oapv_memset_x128_avx()` function to replace the current mapping of `oapv_mset_x128` for avx supported architectures.
- Around `11x` modular Speed-up is observed compared to the current mapping of `memset()`.
- The macro `oapv_mset_x128` is updated in `oapv_port.h`
- The section of `memory operations` in `oapv_port.h` is shifted down after the definition of the macro `X86_SSE`, for using the macro while defining `oapv_mset_x128`