### PR TITLE
Memset speed-up for oapv_mset_x64a

### DIFF
--- a/src/oapv_port.c
+++ b/src/oapv_port.c
@@ -129,14 +129,14 @@ void *oapv_memset_x128_avx(void* dst, int value, size_t size) {
     size_t i = 0;
     // Store 128 units per iteration
     for(; i + 128 < size; i += 128) {
-        _mm_store_si128((__m128i*)(ptr +   0), value_vec);
-        _mm_store_si128((__m128i*)(ptr +  16), value_vec);
-        _mm_store_si128((__m128i*)(ptr +  32), value_vec);
-        _mm_store_si128((__m128i*)(ptr +  48), value_vec);
-        _mm_store_si128((__m128i*)(ptr +  64), value_vec);
-        _mm_store_si128((__m128i*)(ptr +  80), value_vec);
-        _mm_store_si128((__m128i*)(ptr +  96), value_vec);
-        _mm_store_si128((__m128i*)(ptr + 112), value_vec);
+        _mm_store_si128((__m128i*)(ptr + i +   0), value_vec);
+        _mm_store_si128((__m128i*)(ptr + i +  16), value_vec);
+        _mm_store_si128((__m128i*)(ptr + i +  32), value_vec);
+        _mm_store_si128((__m128i*)(ptr + i +  48), value_vec);
+        _mm_store_si128((__m128i*)(ptr + i +  64), value_vec);
+        _mm_store_si128((__m128i*)(ptr + i +  80), value_vec);
+        _mm_store_si128((__m128i*)(ptr + i +  96), value_vec);
+        _mm_store_si128((__m128i*)(ptr + i + 112), value_vec);
     }
     // Remaining full 16-unit blocks
     for (; i + 16 < size; i += 16) {

--- a/src/oapv_port.h
+++ b/src/oapv_port.h
@@ -180,11 +180,12 @@ void *oapv_memset_x128_avx(void* dst, int value, size_t size);
 
 #define oapv_mcpy(dst, src, size)    memcpy((dst), (src), (size))
 #define oapv_mset(dst, v, size)      memset((dst), (v), (size))
-#define oapv_mset_x64a(dst, v, size) memset((dst), (v), (size))
 #if X86_SSE
 #define oapv_mset_x128(dst, v, size) oapv_memset_x128_avx((dst), (v), (size))
+#define oapv_mset_x64a(dst, v, size) oapv_memset_x128_avx((dst), (v), (size))
 #else
 #define oapv_mset_x128(dst, v, size) memset((dst), (v), (size))
+#define oapv_mset_x64a(dst, v, size) memset((dst), (v), (size))
 #endif
 #define oapv_mcmp(dst, src, size)    memcmp((dst), (src), (size))
 


### PR DESCRIPTION
- Debug oapv_memset_x128_avx() code. Added missing iterator.
- Pointed oapv_mset_x64a to oapv_memset_x128_avx() as a temporary speed-up measure.