### PR TITLE
fix get_num_tiles() calculation in imhex patter file

### DIFF
--- a/util/apv.hexpat
+++ b/util/apv.hexpat
@@ -122,8 +122,8 @@ fn get_num_tiles (auto tile_w_mb, auto tile_h_mb, auto w, auto h) {
     u32 TileCols = 0;
     u32 TileRows = 0;
 
-    w_mb = (w + 7) >> 3;
-    h_mb = (h + 7) >> 3;
+    w_mb = (w + 15) >> 4;
+    h_mb = (h + 15) >> 4;
 
     TileCols = 0;
     startMb = 0;


### PR DESCRIPTION
The macroblock width and height is 16. So for an example file like tile_A.apv, where `tile_width_in_mbs` is 240 and `tile_height_in_mbs` is 135, for 3840 x 2160, there is only one tile.