### PR TITLE
CMake: install the libraries in prefix/lib

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -108,7 +108,7 @@ if(MSVC)
 elseif(UNIX OR MINGW)
   if (ARM)
     set_property(SOURCE ${NEON} APPEND PROPERTY COMPILE_FLAGS "-flax-vector-conversions")
-elseif (X86 OR UNIVERSAL)
+  elseif (X86 OR UNIVERSAL)
     set_property(SOURCE ${SSE} APPEND PROPERTY COMPILE_FLAGS "-msse4.1")
     set_property(SOURCE ${AVX} APPEND PROPERTY COMPILE_FLAGS " -mavx2")
   endif()
@@ -142,20 +142,20 @@ set(OAPV_PRIVATE_HEADERS "${LIB_BASE_INC}" "${LIB_SSE_INC}" "${LIB_AVX_INC}" "${
 
 # Install static library and public headers
 #
-# Static library (liboapv.a or oapv.lib) will be installed to <prefix>/lib/oapv
+# Static library (liboapv.a or oapv.lib) will be installed to <prefix>/lib
 # Public headers will be installed to <prefix>/include/oapv
 #
 if(OAPV_BUILD_STATIC_LIB)
   set_target_properties(${LIB_NAME_BASE} PROPERTIES PUBLIC_HEADER "${OAPV_PUBLIC_HEADERS}")
   install(TARGETS ${LIB_NAME_BASE}
-          ARCHIVE COMPONENT Development DESTINATION ${CMAKE_INSTALL_LIBDIR}/${LIB_NAME_BASE}
+          ARCHIVE COMPONENT Development DESTINATION ${CMAKE_INSTALL_LIBDIR}
           PUBLIC_HEADER COMPONENT Development DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${LIB_NAME_BASE}
   )
 endif()
 
 # Install shared library
 #
-# On non-DLL platforms shared library (liboapv.so) will be installed to <prefix>/lib/oapv.
+# On non-DLL platforms shared library (liboapv.so) will be installed to <prefix>/lib.
 # On DLL platforms the shred DLL (oapv.dll) will be installed to <prefix>/bin and its import library will be installed to <prefix>/lib/oapv/import
 #
 if(OAPV_BUILD_SHARED_LIB)
@@ -165,7 +165,7 @@ if(OAPV_BUILD_SHARED_LIB)
           LIBRARY
             COMPONENT Libraries DESTINATION ${CMAKE_INSTALL_LIBDIR}
             NAMELINK_COMPONENT Development DESTINATION ${CMAKE_INSTALL_LIBDIR}
-          ARCHIVE COMPONENT Development DESTINATION ${CMAKE_INSTALL_LIBDIR}/${LIB_NAME_BASE}/import
+          ARCHIVE COMPONENT Development DESTINATION ${CMAKE_INSTALL_LIBDIR}/import
           PUBLIC_HEADER COMPONENT Development DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${LIB_NAME_BASE}
   )
 


### PR DESCRIPTION
Libraries are usually not installed in prefix/lib/somename. 

This matches what the .pc file is saying about the library location:
> @CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@