### PR TITLE
ci: Add dependency cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 14


### PR DESCRIPTION
Use dependency cooldown to mitigate supply chain attacks.