### PR TITLE
64bit Bitstream reading and writing for very large codeword

### DIFF
--- a/src/oapv_bs.c
+++ b/src/oapv_bs.c
@@ -36,7 +36,7 @@
 #if ENABLE_ENCODER
 ///////////////////////////////////////////////////////////////////////////////
 /* number of bytes to be sunk */
-#define BSW_GET_SINK_BYTE(bs) ((32 - (bs)->leftbits + 7) >> 3)
+#define BSW_GET_SINK_BYTE(bs) ((64 - (bs)->leftbits + 7) >> 3)
 
 static int bsw_flush(oapv_bs_t *bs, int bytes)
 {
@@ -46,11 +46,11 @@ static int bsw_flush(oapv_bs_t *bs, int bytes)
     oapv_assert_rv(bs->cur + bytes <= bs->end, -1);
 
     while(bytes--) {
-        *bs->cur++ = (bs->code >> 24) & 0xFF;
+        *bs->cur++ = (bs->code >> 56) & 0xFF;
         bs->code <<= 8;
     }
 
-    bs->leftbits = 32;
+    bs->leftbits = 64;
 
     return 0;
 }
@@ -62,7 +62,7 @@ void oapv_bsw_init(oapv_bs_t *bs, u8 *buf, int size, oapv_bs_fn_flush_t fn_flush
     bs->cur = buf;
     bs->end = buf + size;
     bs->code = 0;
-    bs->leftbits = 32;
+    bs->leftbits = 64;
     bs->fn_flush = (fn_flush == NULL ? bsw_flush : fn_flush);
 }
 
@@ -76,7 +76,7 @@ void *oapv_bsw_sink(oapv_bs_t *bs)
     oapv_assert_rv(bs->cur + BSW_GET_SINK_BYTE(bs) < bs->end, NULL);
     bs->fn_flush(bs, 0);
     bs->code = 0;
-    bs->leftbits = 32;
+    bs->leftbits = 64;
     return (void *)bs->cur;
 }
 
@@ -107,21 +107,21 @@ int oapv_bsw_write1(oapv_bs_t *bs, int val)
         bs->fn_flush(bs, 0);
 
         bs->code = 0;
-        bs->leftbits = 32;
+        bs->leftbits = 64;
     }
 
     return 0;
 }
 
-int oapv_bsw_write(oapv_bs_t *bs, u32 val, int len) /* len(1 ~ 32) */
+int oapv_bsw_write(oapv_bs_t *bs, u32 val, int len)
 {
     int leftbits;
 
     oapv_assert(bs);
 
     leftbits = bs->leftbits;
-    val <<= (32 - len);
-    bs->code |= (val >> (32 - leftbits));
+    val <<= (64 - len);
+    bs->code |= (val >> (64 - leftbits));
 
     if(len < leftbits) {
         bs->leftbits -= len;
@@ -129,8 +129,8 @@ int oapv_bsw_write(oapv_bs_t *bs, u32 val, int len) /* len(1 ~ 32) */
     else {
         bs->leftbits = 0;
         bs->fn_flush(bs, 0);
-        bs->code = (leftbits < 32 ? val << leftbits : 0);
-        bs->leftbits = 32 - (len - leftbits);
+        bs->code = (leftbits < 64 ? val << leftbits : 0);
+        bs->leftbits = 64 - (len - leftbits);
     }
 
     return 0;
@@ -156,7 +156,7 @@ static void inline bsr_skip_code(oapv_bs_t *bs, int size)
 {
     oapv_assert(size <= 32);
     oapv_assert(bs->leftbits >= size);
-    if(size == 32) {
+    if(size == 64) {
         bs->code = 0;
         bs->leftbits = 0;
     }
@@ -168,7 +168,7 @@ static void inline bsr_skip_code(oapv_bs_t *bs, int size)
 
 static int bsr_flush(oapv_bs_t *bs, int byte)
 {
-    int shift = 24, remained;
+    int shift = 56, remained;
     u32 code = 0;
 
     oapv_assert(byte);
@@ -210,11 +210,11 @@ int oapv_bsr_clz_in_code(u32 code)
     int clz, bits4, shift;
 
     if(code == 0)
-        return 32; /* to protect infinite loop */
+        return 64; /* to protect infinite loop */
 
     bits4 = 0;
     clz = 0;
-    shift = 28;
+    shift = 56;
 
     while(bits4 == 0 && shift >= 0) {
         bits4 = (code >> shift) & 0xf;
@@ -229,7 +229,7 @@ int oapv_bsr_clz(oapv_bs_t *bs)
     int clz;
     u32 code;
 
-    code = oapv_bsr_peek(bs, 32);
+    code = oapv_bsr_peek(bs, 64); /* supports max 64bit codeword */
     oapv_assert(code != 0);
     clz = oapv_bsr_clz_in_code(code);
     return clz;
@@ -256,7 +256,7 @@ void oapv_bsr_skip(oapv_bs_t *bs, int size)
 
     if(bs->leftbits < size) {
         size -= bs->leftbits;
-        if(bs->fn_flush(bs, 4)) {
+        if(bs->fn_flush(bs, 8)) {
             // oapv_trace("already reached the end of bitstream\n");  /* should be updated */
             return;
         }
@@ -270,7 +270,7 @@ u32 oapv_bsr_peek(oapv_bs_t *bs, int size)
     u32 code = 0;
 
     if(bs->leftbits < size) {
-        byte = (32 - bs->leftbits) >> 3;
+        byte = (64 - bs->leftbits) >> 3;
 
         /* We should not check the return value
         because this function could be failed at the EOB. */
@@ -286,9 +286,9 @@ u32 oapv_bsr_peek(oapv_bs_t *bs, int size)
         }
     }
 
-    oapv_assert(bs->leftbits <= 32);
+    oapv_assert(bs->leftbits <= 64);
 
-    code = bs->code >> (32 - size);
+    code = bs->code >> (64 - size);
     size -= bs->leftbits;
 
     if(size > 0) {
@@ -327,14 +327,14 @@ u32 oapv_bsr_read(oapv_bs_t *bs, int size)
     oapv_assert(size > 0);
 
     if(bs->leftbits < size) {
-        code = bs->code >> (32 - size);
+        code = bs->code >> (64 - size);
         size -= bs->leftbits;
-        if(bs->fn_flush(bs, 4)) {
+        if(bs->fn_flush(bs, 8)) {
             oapv_trace("already reached the end of bitstream\n"); /* should be updated */
             return (u32)(-1);
         }
     }
-    code |= bs->code >> (32 - size);
+    code |= bs->code >> (64 - size);
 
     bsr_skip_code(bs, size);
 
@@ -345,12 +345,12 @@ int oapv_bsr_read1(oapv_bs_t *bs)
 {
     int code;
     if(bs->leftbits == 0) {
-        if(bs->fn_flush(bs, 4)) {
+        if(bs->fn_flush(bs, 8)) {
             oapv_trace("already reached the end of bitstream\n"); /* should be updated */
             return -1;
         }
     }
-    code = (int)(bs->code >> 31);
+    code = (int)(bs->code >> 63);
 
     bs->code <<= 1;
     bs->leftbits -= 1;
@@ -361,7 +361,7 @@ int oapv_bsr_read1(oapv_bs_t *bs)
 u32 oapv_bsr_read_direct(void *addr, int len)
 {
     u32 code = 0;
-    int shift = 24;
+    int shift = 56;
     u8 *p = (u8 *)addr;
     int byte = (len + 7) >> 3;
 
@@ -373,7 +373,7 @@ u32 oapv_bsr_read_direct(void *addr, int len)
         byte--;
         p++;
     }
-    code = code >> (32 - len);
+    code = code >> (64 - len);
     return code;
 }
 

--- a/src/oapv_bs.c
+++ b/src/oapv_bs.c
@@ -112,30 +112,7 @@ int oapv_bsw_write1(oapv_bs_t *bs, int val)
 
     return 0;
 }
-#if 0
-int oapv_bsw_write(oapv_bs_t *bs, u32 val, int len)
-{
-    int leftbits;
 
-    oapv_assert(bs);
-
-    leftbits = bs->leftbits;
-    val <<= (32 - len);
-    bs->code |= (val >> (64 - leftbits));
-
-    if(len < leftbits) {
-        bs->leftbits -= len;
-    }
-    else {
-        bs->leftbits = 0;
-        bs->fn_flush(bs, 0);
-        bs->code = (leftbits < 64 ? val << leftbits : 0);
-        bs->leftbits = 64 - (len - leftbits);
-    }
-
-    return 0;
-}
-#else
 int oapv_bsw_write(oapv_bs_t *bs, u32 val, int len)
 {
     int leftbits;
@@ -155,10 +132,8 @@ int oapv_bsw_write(oapv_bs_t *bs, u32 val, int len)
         bs->code = code_t << leftbits;
         bs->leftbits = 64 - (len - leftbits);
     }
-
     return 0;
 }
-#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 // end of encoder code

--- a/src/oapv_bs.c
+++ b/src/oapv_bs.c
@@ -112,7 +112,7 @@ int oapv_bsw_write1(oapv_bs_t *bs, int val)
 
     return 0;
 }
-
+#if 0
 int oapv_bsw_write(oapv_bs_t *bs, u32 val, int len)
 {
     int leftbits;
@@ -120,7 +120,7 @@ int oapv_bsw_write(oapv_bs_t *bs, u32 val, int len)
     oapv_assert(bs);
 
     leftbits = bs->leftbits;
-    val <<= (64 - len);
+    val <<= (32 - len);
     bs->code |= (val >> (64 - leftbits));
 
     if(len < leftbits) {
@@ -135,6 +135,30 @@ int oapv_bsw_write(oapv_bs_t *bs, u32 val, int len)
 
     return 0;
 }
+#else
+int oapv_bsw_write(oapv_bs_t *bs, u32 val, int len)
+{
+    int leftbits;
+    u64 code_t;
+
+    oapv_assert(bs);
+
+    leftbits = bs->leftbits;
+    code_t = ((u64)val) << (64 - len);
+    bs->code |= (code_t >> (64 - leftbits));
+
+    if(len < leftbits) {
+        bs->leftbits -= len;
+    }
+    else {
+        bs->fn_flush(bs, 8);
+        bs->code = code_t << leftbits;
+        bs->leftbits = 64 - (len - leftbits);
+    }
+
+    return 0;
+}
+#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 // end of encoder code
@@ -169,7 +193,7 @@ static void inline bsr_skip_code(oapv_bs_t *bs, int size)
 static int bsr_flush(oapv_bs_t *bs, int byte)
 {
     int shift = 56, remained;
-    u32 code = 0;
+    u64 code = 0;
 
     oapv_assert(byte);
 
@@ -186,7 +210,7 @@ static int bsr_flush(oapv_bs_t *bs, int byte)
     bs->leftbits = byte << 3;
 
     while(byte) {
-        code |= *(bs->cur++) << shift;
+        code |= (u64)(*(bs->cur++)) << shift;
         byte--;
         shift -= 8;
     }
@@ -334,7 +358,7 @@ u32 oapv_bsr_read(oapv_bs_t *bs, int size)
             return (u32)(-1);
         }
     }
-    code |= bs->code >> (64 - size);
+    code |= (u32)(bs->code >> (64 - size));
 
     bsr_skip_code(bs, size);
 
@@ -361,7 +385,7 @@ int oapv_bsr_read1(oapv_bs_t *bs)
 u32 oapv_bsr_read_direct(void *addr, int len)
 {
     u32 code = 0;
-    int shift = 56;
+    int shift = 24;
     u8 *p = (u8 *)addr;
     int byte = (len + 7) >> 3;
 
@@ -373,8 +397,7 @@ u32 oapv_bsr_read_direct(void *addr, int len)
         byte--;
         p++;
     }
-    code = code >> (64 - len);
-    return code;
+    return (code >> (32 - len));
 }
 
 

--- a/src/oapv_bs.h
+++ b/src/oapv_bs.h
@@ -38,7 +38,7 @@ typedef struct oapv_bs oapv_bs_t;
 typedef int (*oapv_bs_fn_flush_t)(oapv_bs_t *bs, int byte);
 
 struct oapv_bs {
-    u32                code;     // intermediate code buffer
+    u64                code;     // intermediate code buffer
     int                leftbits; // left bits count in code
     u8                *cur;      // address of current bitstream position
     u8                *end;      // address of bitstream end
@@ -94,7 +94,7 @@ should set zero in that case. */
 #endif
 #else
 #define BSR_SKIP_CODE(bs, size) \
-    oapv_assert((bs)->leftbits >= (size) && (size) <= 32); \
+    oapv_assert((bs)->leftbits >= (size) && (size) <= 64); \
     (bs)->code <<= (size); (bs)->leftbits -= (size);
 #endif
 

--- a/src/oapv_bs.h
+++ b/src/oapv_bs.h
@@ -54,6 +54,12 @@ struct oapv_bs {
 #if ENABLE_ENCODER
 ///////////////////////////////////////////////////////////////////////////////
 
+/* move current write position to a specific bitstream address */
+#define BSW_MOVE_CUR(bs, addr) \
+    (bs)->cur = addr; \
+    (bs)->code = 0; \
+    (bs)->leftbits = 64;
+
 static inline bool bsw_is_align8(oapv_bs_t *bs)
 {
     return (bool)(!((bs)->leftbits & 0x7));
@@ -94,7 +100,8 @@ should set zero in that case. */
 #endif
 #else
 #define BSR_SKIP_CODE(bs, size) \
-    oapv_assert((bs)->leftbits >= (size) && (size) <= 64); \
+    /* 64bit is missing here to avoid the arithmetic left shift */ \
+    oapv_assert((bs)->leftbits >= (size) && (size) < 64); \
     (bs)->code <<= (size); (bs)->leftbits -= (size);
 #endif
 

--- a/src/oapv_vlc.c
+++ b/src/oapv_vlc.c
@@ -77,18 +77,23 @@
     }
 
 #define BSW_WRITE_64BITS(bs, code64, nbits) { \
-        (code64) <<= (64 - nbits); \
-        while((nbits) >= (bs)->leftbits) { \
-            (bs)->code |= ((code64) >> (64 - (bs)->leftbits)); \
-            (code64) <<= (bs)->leftbits; \
-            (nbits) -= (bs)->leftbits; \
-            BSW_FLUSH_4BYTE(bs); \
-        } \
-        if((nbits) > 0) { \
+        (code64) <<= (64 - (nbits)); \
+        if((nbits) < (bs)->leftbits) { \
             (bs)->code |= ((code64) >> (64 - (bs)->leftbits)); \
             (bs)->leftbits -= (nbits); \
         } \
+        else { \
+            (bs)->code |= ((code64) >> (64 - (bs)->leftbits)); \
+            (code64) <<= (bs)->leftbits; \
+            (nbits) -= (bs)->leftbits; \
+            BSW_FLUSH_8BYTE(bs); \
+            if((nbits) > 0) { \
+                (bs)->code |= ((code64) >> (64 - (bs)->leftbits)); \
+                (bs)->leftbits -= (nbits); \
+            } \
+        } \
     }
+
 
 #define ADD_BITS_TO_CODE(val, nb, code) ((code) << (nb) | (val))
 
@@ -96,7 +101,7 @@ static const u8 enc_prefix_vlc[3][2] = {{1, 0xFF}, {0, 0}, {0, 1}}; // 0xFF is d
 
 static void enc_vlc_write(oapv_bs_t *bs, int val, int k)
 {
-    u32 code = 0;
+    u64 code = 0; /* this value can exceed 32bit in custom QP matrix with all '1' */
     u32 symbol = val;
     int nb = 0;
     int vlc_idx = oapv_min(val >> k, 2);  // 'val' is always positive or zero
@@ -124,16 +129,12 @@ static void enc_vlc_write(oapv_bs_t *bs, int val, int k)
         nb += k;
     }
     // write to bitstream buffer
-#if 0 // TODO
-    BSW_WRITE_32BITS(bs, code, nb);
-#else
-    oapv_bsw_write(bs, code, nb);
-#endif
+    BSW_WRITE_64BITS(bs, code, nb);
 }
 
-static u32 enc_vlc_write_to_code(oapv_bs_t *bs, int val, int k, int *nbits)
+static u64 enc_vlc_write_to_code(oapv_bs_t *bs, int val, int k, int *nbits)
 {
-    u32 code = 0;
+    u64 code64 = 0;
     u32 symbol = val;
     int nb = 0;
     int vlc_idx = oapv_min(val >> k, 2);  // 'val' is always positive or zero
@@ -141,28 +142,28 @@ static u32 enc_vlc_write_to_code(oapv_bs_t *bs, int val, int k, int *nbits)
     while(symbol >= (1 << k)) {
         symbol -= (1 << k);
         if(nb < 2) {
-            code = ADD_BITS_TO_CODE(enc_prefix_vlc[vlc_idx][nb], 1, code);
+            code64 = ADD_BITS_TO_CODE(enc_prefix_vlc[vlc_idx][nb], 1, code64);
         }
         else {
-            code = ADD_BITS_TO_CODE(0, 1, code);
+            code64 = ADD_BITS_TO_CODE(0, 1, code64);
             k++;
         }
         nb++;
     }
     if(nb < 2) {
-        code = ADD_BITS_TO_CODE(enc_prefix_vlc[vlc_idx][nb], 1, code);
+        code64 = ADD_BITS_TO_CODE(enc_prefix_vlc[vlc_idx][nb], 1, code64);
     }
     else {
-        code = ADD_BITS_TO_CODE(1, 1, code);
+        code64 = ADD_BITS_TO_CODE(1, 1, code64);
 
     }
     nb++;
     if(k > 0) {
-        code = ADD_BITS_TO_CODE(symbol, k, code);
+        code64 = ADD_BITS_TO_CODE(symbol, k, code64);
         nb += k;
     }
     *nbits = nb;
-    return code;
+    return code64;
 }
 
 static int enc_vlc_quantization_matrix(oapv_bs_t *bs, oapve_ctx_t *ctx, oapv_fh_t *fh)
@@ -197,26 +198,22 @@ static int enc_vlc_tile_info(oapv_bs_t *bs, oapve_ctx_t *ctx, oapv_fh_t *fh)
 
 int oapve_vlc_dc_coef(oapv_bs_t *bs, int dc_diff, int *kparam_dc)
 {
-    u32 code;
+    u64 code64 = 0; /* this value can exceed 32bit in custom QP matrix with all '1' */
     int nbits;
     int abs_dc_diff = oapv_abs32(dc_diff);
 
-    code = enc_vlc_write_to_code(bs, abs_dc_diff, *kparam_dc, &nbits);
+    code64 = enc_vlc_write_to_code(bs, abs_dc_diff, *kparam_dc, &nbits);
 
     if(abs_dc_diff) {
         int sign_dc_diff = oapv_get_sign32(dc_diff);
-        code = ADD_BITS_TO_CODE(sign_dc_diff, 1, code);
+        code64 = ADD_BITS_TO_CODE(sign_dc_diff, 1, code64);
         *kparam_dc = KPARAM_DC(abs_dc_diff);
         nbits++;
     }
     else {
         *kparam_dc = OAPV_KPARAM_DC_MIN;
     }
-#if 0 // TODO
-    BSW_WRITE_32BITS(bs, code, nbits);
-#else
-    oapv_bsw_write(bs, code, nbits);
-#endif
+    BSW_WRITE_64BITS(bs, code64, nbits);
 
     return OAPV_OK;
 }
@@ -229,31 +226,28 @@ void oapve_vlc_ac_coef(oapv_bs_t* bs, s16* coef, int * kparam_ac)
     const u8 *scanp = oapv_tbl_scan;
     int       k_run = OAPV_KPARAM_RUN_MIN;
     int       k_ac = *kparam_ac;
-    u32       code;
+    u64       code64;
     int       nbits;
 
     for (scan_pos = 1; scan_pos < OAPV_BLK_D; scan_pos++) {
         c = coef[scanp[scan_pos]];
         if(c) {
             // run coding
-            code = oapve_tbl_vlc_code[run][k_run][0];
+            code64 = oapve_tbl_vlc_code[run][k_run][0];
             nbits = oapve_tbl_vlc_code[run][k_run][1];
             k_run = KPARAM_RUN(run); // update kparam for run
             run = 0; // reset run
-#if 0 // TODO
-            BSW_WRITE_32BITS(bs, code, nbits);
-#else
-            oapv_bsw_write(bs, code, nbits);
-#endif
+
+            BSW_WRITE_64BITS(bs, code64, nbits);
 
             // level and sign coding
             level = oapv_abs16(c);
             if(level < 101) { // early termination
-                code  = oapve_tbl_vlc_code[level - 1][k_ac][0];
+                code64  = oapve_tbl_vlc_code[level - 1][k_ac][0];
                 nbits = oapve_tbl_vlc_code[level - 1][k_ac][1];
             }
             else {
-                code = enc_vlc_write_to_code(bs, level - 1, k_ac, &nbits);
+                code64 = enc_vlc_write_to_code(bs, level - 1, k_ac, &nbits);
             }
             k_ac = KPARAM_AC(level);
             if (first_ac) {
@@ -261,26 +255,20 @@ void oapve_vlc_ac_coef(oapv_bs_t* bs, s16* coef, int * kparam_ac)
                 *kparam_ac = k_ac;
             }
             sign  = oapv_get_sign16(c);
-            code = ADD_BITS_TO_CODE(sign, 1, code);
+            code64 = ADD_BITS_TO_CODE(sign, 1, code64);
             nbits++;
-#if 0 // TODO
-            BSW_WRITE_32BITS(bs, code, nbits);
-#else
-            oapv_bsw_write(bs, code, nbits);
-#endif
+
+            BSW_WRITE_64BITS(bs, code64, nbits);
         }
         else { // zero coefficent value
             run++;
         }
     }
     if(run > 0) { // last position can be zero
-        code = oapve_tbl_vlc_code[run][k_run][0];
+        code64 = oapve_tbl_vlc_code[run][k_run][0];
         nbits = oapve_tbl_vlc_code[run][k_run][1];
-#if 0 // TODO
-        BSW_WRITE_32BITS(bs, code, nbits);
-#else
-        oapv_bsw_write(bs, code, nbits);
-#endif
+
+        BSW_WRITE_64BITS(bs, code64, nbits);
     }
 }
 
@@ -1120,7 +1108,7 @@ int oapvd_vlc_tile_header(oapv_bs_t *bs, oapvd_ctx_t *ctx, oapv_th_t *th)
 
 int oapvd_vlc_tile_dummy_data(oapv_bs_t *bs)
 {
-    while(bs->cur < bs->end) {
+    while(BSR_GET_LEFT_BYTE(bs) > 0) {
         oapv_bsr_read(bs, 8);
     }
     return OAPV_OK;
@@ -1134,7 +1122,7 @@ int oapvd_vlc_metadata(oapv_bs_t *bs, u32 pbu_size, oapvm_t mid, int group_id)
     metadata_size = oapv_bsr_read(bs, 32);
     DUMP_HLS(metadata_size, metadata_size);
     oapv_assert_gv(pbu_size >= 8 && metadata_size <= (pbu_size - 8), ret, OAPV_ERR_MALFORMED_BITSTREAM, ERR);
-    u8 *bs_start_pos = bs->cur;
+    u8 *bs_start_pos = oapv_bsr_sink(bs);
     u8 *payload_data = NULL;
 
     while(metadata_size > 0) {
@@ -1168,8 +1156,7 @@ int oapvd_vlc_metadata(oapv_bs_t *bs, u32 pbu_size, oapvm_t mid, int group_id)
         payload_data = oapv_bsr_sink(bs);
 #if ENC_DEC_DUMP
         for(int i = 0; i < payload_size; i++) {
-            t0 = bs->cur[i];
-            DUMP_HLS(payload_data, t0);
+            DUMP_HLS(payload_data, payload_data[i]);
         }
 #endif
         if (payload_size == 0) {
@@ -1181,9 +1168,12 @@ int oapvd_vlc_metadata(oapv_bs_t *bs, u32 pbu_size, oapvm_t mid, int group_id)
         metadata_size -= payload_size;
     }
     const u32 target_read_size = (pbu_size - 8);
-    oapv_assert_gv(target_read_size >= (bs->cur - bs_start_pos), ret, OAPV_ERR_MALFORMED_BITSTREAM, ERR);
-    ret = oapvd_vlc_filler(bs, target_read_size - (bs->cur - bs_start_pos));
-    oapv_assert_g(OAPV_SUCCEEDED(ret), ERR);
+    int filler_size = target_read_size - ((u8*)oapv_bsr_sink(bs) - bs_start_pos);
+    oapv_assert_gv(filler_size >= 0, ret, OAPV_ERR_MALFORMED_BITSTREAM, ERR);
+    if(filler_size > 0) {
+        ret = oapvd_vlc_filler(bs, filler_size);
+        oapv_assert_g(OAPV_SUCCEEDED(ret), ERR);
+    }
     return OAPV_OK;
 
 ERR:

--- a/src/oapv_vlc.c
+++ b/src/oapv_vlc.c
@@ -45,6 +45,19 @@
         (bs)->leftbits = 32;                      \
     }
 
+#define BSW_FLUSH_8BYTE(bs) {                     \
+        *(bs)->cur++ = ((bs)->code >> 56) & 0xFF; \
+        *(bs)->cur++ = ((bs)->code >> 48) & 0xFF; \
+        *(bs)->cur++ = ((bs)->code >> 40) & 0xFF; \
+        *(bs)->cur++ = ((bs)->code >> 32) & 0xFF; \
+        *(bs)->cur++ = ((bs)->code >> 24) & 0xFF; \
+        *(bs)->cur++ = ((bs)->code >> 16) & 0xFF; \
+        *(bs)->cur++ = ((bs)->code >> 8) & 0xFF;  \
+        *(bs)->cur++ = ((bs)->code) & 0xFF;       \
+        (bs)->code = 0;                           \
+        (bs)->leftbits = 64;                      \
+    }
+
 #define BSW_WRITE_32BITS(bs, code32, nbits) { \
         (code32) <<= (32 - (nbits)); \
         if((nbits) < (bs)->leftbits) { \
@@ -111,7 +124,11 @@ static void enc_vlc_write(oapv_bs_t *bs, int val, int k)
         nb += k;
     }
     // write to bitstream buffer
+#if 0 // TODO
     BSW_WRITE_32BITS(bs, code, nb);
+#else
+    oapv_bsw_write(bs, code, nb);
+#endif
 }
 
 static u32 enc_vlc_write_to_code(oapv_bs_t *bs, int val, int k, int *nbits)
@@ -175,7 +192,6 @@ static int enc_vlc_tile_info(oapv_bs_t *bs, oapve_ctx_t *ctx, oapv_fh_t *fh)
             DUMP_HLS(fh->tile_size, fh->tile_size[i]);
         }
     }
-
     return 0;
 }
 
@@ -196,7 +212,12 @@ int oapve_vlc_dc_coef(oapv_bs_t *bs, int dc_diff, int *kparam_dc)
     else {
         *kparam_dc = OAPV_KPARAM_DC_MIN;
     }
+#if 0 // TODO
     BSW_WRITE_32BITS(bs, code, nbits);
+#else
+    oapv_bsw_write(bs, code, nbits);
+#endif
+
     return OAPV_OK;
 }
 
@@ -219,7 +240,11 @@ void oapve_vlc_ac_coef(oapv_bs_t* bs, s16* coef, int * kparam_ac)
             nbits = oapve_tbl_vlc_code[run][k_run][1];
             k_run = KPARAM_RUN(run); // update kparam for run
             run = 0; // reset run
+#if 0 // TODO
             BSW_WRITE_32BITS(bs, code, nbits);
+#else
+            oapv_bsw_write(bs, code, nbits);
+#endif
 
             // level and sign coding
             level = oapv_abs16(c);
@@ -238,7 +263,11 @@ void oapve_vlc_ac_coef(oapv_bs_t* bs, s16* coef, int * kparam_ac)
             sign  = oapv_get_sign16(c);
             code = ADD_BITS_TO_CODE(sign, 1, code);
             nbits++;
+#if 0 // TODO
             BSW_WRITE_32BITS(bs, code, nbits);
+#else
+            oapv_bsw_write(bs, code, nbits);
+#endif
         }
         else { // zero coefficent value
             run++;
@@ -247,7 +276,11 @@ void oapve_vlc_ac_coef(oapv_bs_t* bs, s16* coef, int * kparam_ac)
     if(run > 0) { // last position can be zero
         code = oapve_tbl_vlc_code[run][k_run][0];
         nbits = oapve_tbl_vlc_code[run][k_run][1];
+#if 0 // TODO
         BSW_WRITE_32BITS(bs, code, nbits);
+#else
+        oapv_bsw_write(bs, code, nbits);
+#endif
     }
 }
 
@@ -593,13 +626,13 @@ int oapve_vlc_get_coef_rate(oapve_core_t* core, s16* coef, int c)
 // start of decoder code
 #if ENABLE_DECODER
 ///////////////////////////////////////////////////////////////////////////////
-#define BSR_FLUSH_1BYTE(bs) {                   \
-        (bs)->code = *((bs)->cur++) << 24;      \
-        (bs)->leftbits = 8;                     \
+#define BSR_FLUSH_1BYTE(bs) {                       \
+        (bs)->code = ((u64)(*((bs)->cur++))) << 56; \
+        (bs)->leftbits = 8;                         \
     }
 
 #define BSR_READ_1BIT(bs, bit) {                \
-        (bit) = ((bs)->code >> 31) & 0x1;       \
+        (bit) = ((bs)->code >> 63) & 0x1;       \
         (bs)->code <<= 1;                       \
         (bs)->leftbits -= 1;                    \
     }
@@ -627,11 +660,11 @@ static int dec_vlc_read_kparam0(oapv_bs_t *bs)
         symbol += ((u32)0xFFFFFFFF) >> (32 - k);
 
         while(bs->leftbits < k) {
-            symbol += bs->code >> (32 - k);
+            symbol += bs->code >> (64 - k);
             k -= bs->leftbits;
             BSR_FLUSH_1BYTE(bs);
         }
-        symbol += bs->code >> (32 - k);
+        symbol += bs->code >> (64 - k);
         bs->code <<= k;
         bs->leftbits -= k;
     }
@@ -665,11 +698,11 @@ static int dec_vlc_read_1bit_read(oapv_bs_t *bs)
         symbol += ((u32)0xFFFFFFFF) >> (32 - k);
 
         while(bs->leftbits < k) {
-            symbol += bs->code >> (32 - k);
+            symbol += bs->code >> (64 - k);
             k -= bs->leftbits;
             BSR_FLUSH_1BYTE(bs);
         }
-        symbol += bs->code >> (32 - k);
+        symbol += bs->code >> (64 - k);
         bs->code <<= k;
         bs->leftbits -= k;
     }
@@ -711,11 +744,11 @@ static int dec_vlc_read(oapv_bs_t *bs, int k)
     }
     if(k > 0) {
         while(bs->leftbits < k) {
-            symbol += bs->code >> (32 - k);
+            symbol += bs->code >> (64 - k);
             k -= bs->leftbits;
             BSR_FLUSH_1BYTE(bs);
         }
-        symbol += bs->code >> (32 - k);
+        symbol += bs->code >> (64 - k);
         bs->code <<= k;
         bs->leftbits -= k;
     }


### PR DESCRIPTION
- To tackle issue # https://github.com/AcademySoftwareFoundation/openapv/issues/169
  * in case of very low QP matrix, it can lead 33bit codeword, which is not suitable to the previous implementation.
  * patched the bitstream reader and writer to support codewords more than 32bits. 