### PR TITLE
Handling fuzz test in tile size

### DIFF
--- a/src/oapv.c
+++ b/src/oapv.c
@@ -1667,8 +1667,8 @@ static int dec_tile(oapvd_core_t *core, oapvd_tile_t *tile)
     oapvd_ctx_t *ctx = core->ctx;
     oapv_bs_t    bs; // bs for 'tile()' syntax
 
-    oapv_bsr_init(&bs, tile->bs_beg + OAPV_TILE_SIZE_LEN, tile->data_size, NULL);
-    ret = oapvd_vlc_tile_header(&bs, ctx, &tile->th);
+    oapv_bsr_init(&bs, tile->bs_beg + OAPV_TILE_SIZE_LEN, tile->tile_size, NULL);
+    ret = oapvd_vlc_tile_header(&bs, ctx->num_comp, &tile->th, tile->tile_size);
     oapv_assert_rv(OAPV_SUCCEEDED(ret), ret);
 
     for(c = 0; c < ctx->num_comp; c++) {
@@ -1752,16 +1752,16 @@ static int dec_thread_tile(void *arg)
         }
         /* read tile size */
         oapv_bsr_init(&bs, tile[tile_idx].bs_beg, OAPV_TILE_SIZE_LEN, NULL);
-        ret = oapvd_vlc_tile_size(&bs, &tile[tile_idx].data_size);
+        ret = oapvd_vlc_tile_size(&bs, &tile[tile_idx].tile_size);
         oapv_assert_g(OAPV_SUCCEEDED(ret), ERR);
-        oapv_assert_g(tile[tile_idx].bs_beg + OAPV_TILE_SIZE_LEN + (tile[tile_idx].data_size - 1) <= ctx->bs.end, ERR);
+        oapv_assert_g(tile[tile_idx].bs_beg + OAPV_TILE_SIZE_LEN + (tile[tile_idx].tile_size - 1) <= ctx->bs.end, ERR);
 
         oapv_tpool_enter_cs(ctx->sync_obj);
         if(tile_idx + 1 < ctx->num_tiles) {
-            tile[tile_idx + 1].bs_beg = tile[tile_idx].bs_beg + OAPV_TILE_SIZE_LEN + tile[tile_idx].data_size;
+            tile[tile_idx + 1].bs_beg = tile[tile_idx].bs_beg + OAPV_TILE_SIZE_LEN + tile[tile_idx].tile_size;
         }
         else {
-            ctx->tile_end = tile[tile_idx].bs_beg + OAPV_TILE_SIZE_LEN + tile[tile_idx].data_size;
+            ctx->tile_end = tile[tile_idx].bs_beg + OAPV_TILE_SIZE_LEN + tile[tile_idx].tile_size;
         }
         oapv_tpool_leave_cs(ctx->sync_obj);
 

--- a/src/oapv.c
+++ b/src/oapv.c
@@ -1754,7 +1754,9 @@ static int dec_thread_tile(void *arg)
         oapv_bsr_init(&bs, tile[tile_idx].bs_beg, OAPV_TILE_SIZE_LEN, NULL);
         ret = oapvd_vlc_tile_size(&bs, &tile[tile_idx].tile_size);
         oapv_assert_g(OAPV_SUCCEEDED(ret), ERR);
-        oapv_assert_g(tile[tile_idx].bs_beg + OAPV_TILE_SIZE_LEN + (tile[tile_idx].tile_size - 1) <= ctx->bs.end, ERR);
+
+        /* check the tile data size */
+        oapv_assert_g((OAPV_TILE_SIZE_LEN + tile[tile_idx].tile_size) <= (ctx->bs.end - tile[tile_idx].bs_beg + 1), ERR);
 
         oapv_tpool_enter_cs(ctx->sync_obj);
         if(tile_idx + 1 < ctx->num_tiles) {

--- a/src/oapv_def.h
+++ b/src/oapv_def.h
@@ -341,7 +341,7 @@ struct oapvd_tile {
     int          y;         /* y (row) position in a frame in unit of pixel */
     int          w;         /* tile width in unit of pixel */
     int          h;         /* tile height in unit of pixel */
-    u32          data_size; /* tile size including tile_size syntax */
+    u32          tile_size; /* tile data size (byte size of tile(tileIdx) syntax) */
 
     u8          *bs_beg; /* start position of tile in input bistream */
     u8          *bs_end; /* end position of tile() in input bistream */

--- a/src/oapv_vlc.c
+++ b/src/oapv_vlc.c
@@ -1082,18 +1082,27 @@ int oapvd_vlc_tile_size(oapv_bs_t *bs, u32 *tile_size)
     return OAPV_OK;
 }
 
-int oapvd_vlc_tile_header(oapv_bs_t *bs, oapvd_ctx_t *ctx, oapv_th_t *th)
+int oapvd_vlc_tile_header(oapv_bs_t *bs, int num_comp, oapv_th_t *th, u32 tile_size)
 {
+    u32 read_size = 0;
+
     th->tile_header_size = oapv_bsr_read(bs, 16);
     DUMP_HLS(th->tile_header_size, th->tile_header_size);
+
+    // check 'tile_header_size' syntax value
+    // # of bytes = tile_header_size (2) + tile_index (2) + reserved_zero_8bits (1) + num_comp * (tile_data_size(4) + tile_qp(1))
+    oapv_assert_rv(th->tile_header_size == (5 + (num_comp*5)), OAPV_ERR_MALFORMED_BITSTREAM)
+    read_size += th->tile_header_size;
+
     th->tile_index = oapv_bsr_read(bs, 16);
     DUMP_HLS(th->tile_index, th->tile_index);
-    for(int c = 0; c < ctx->num_comp; c++) {
+    for(int c = 0; c < num_comp; c++) {
         th->tile_data_size[c] = oapv_bsr_read(bs, 32);
         DUMP_HLS(th->tile_data_size, th->tile_data_size[c]);
-        oapv_assert_rv(th->tile_data_size[c] > 0, OAPV_ERR_MALFORMED_BITSTREAM);
+        oapv_assert_rv((tile_size - read_size) >= th->tile_data_size[c], OAPV_ERR_MALFORMED_BITSTREAM);
+        read_size += th->tile_data_size[c];
     }
-    for(int c = 0; c < ctx->num_comp; c++) {
+    for(int c = 0; c < num_comp; c++) {
         th->tile_qp[c] = oapv_bsr_read(bs, 8);
         DUMP_HLS(th->tile_qp, th->tile_qp[c]);
     }

--- a/src/oapv_vlc.h
+++ b/src/oapv_vlc.h
@@ -63,7 +63,7 @@ int  oapvd_vlc_au_info(oapv_bs_t* bs, oapv_aui_t* aui);
 int  oapvd_vlc_frame_header(oapv_bs_t* bs, oapv_fh_t* fh);
 int  oapvd_vlc_frame_info(oapv_bs_t* bs, oapv_fi_t *fi);
 int  oapvd_vlc_tile_size(oapv_bs_t *bs, u32 *tile_size);
-int  oapvd_vlc_tile_header(oapv_bs_t* bs, oapvd_ctx_t* ctx, oapv_th_t* th);
+int  oapvd_vlc_tile_header(oapv_bs_t *bs, int num_comp, oapv_th_t *th, u32 tiles_data_size);
 int  oapvd_vlc_tile_dummy_data(oapv_bs_t* bs);
 int  oapvd_vlc_metadata(oapv_bs_t* bs, u32 pbu_size, oapvm_t mid, int group_id);
 int  oapvd_vlc_filler(oapv_bs_t* bs, u32 filler_size);


### PR DESCRIPTION
+ Add prevention code to handle the malformed bitstream.
   - Driven by fuzz test
   - Fix a memory access over boundary of allocated input bitstream memory.