### PR TITLE
Fuzz fix for large k value

### DIFF
--- a/src/oapv.c
+++ b/src/oapv.c
@@ -1995,7 +1995,7 @@ int oapvd_decode(oapvd_t did, oapv_bitb_t *bitb, oapv_frms_t *ofrms, oapvm_t mid
             ret = dec_frm_prepare(ctx, ofrms->frm[frame_cnt].imgb);
             oapv_assert_g(OAPV_SUCCEEDED(ret), ERR);
 
-            int           res;
+            int           res, ret_thread;
             oapv_tpool_t *tpool = ctx->tpool;
             int           parallel_task = 1;
             int           tidx = 0;
@@ -2007,11 +2007,11 @@ int oapvd_decode(oapvd_t did, oapv_bitb_t *bitb, oapv_frms_t *ofrms, oapvm_t mid
                 tpool->run(ctx->thread_id[tidx], dec_thread_tile,
                            (void *)ctx->core[tidx]);
             }
-            ret = dec_thread_tile((void *)ctx->core[tidx]);
+            ret_thread = dec_thread_tile((void *)ctx->core[tidx]);
             for(tidx = 0; tidx < parallel_task - 1; tidx++) {
                 tpool->join(ctx->thread_id[tidx], &res);
                 if(OAPV_FAILED(res)) {
-                    ret = res;
+                    ret_thread = res;
                 }
             }
             /****************************************************/
@@ -2032,6 +2032,8 @@ int oapvd_decode(oapvd_t did, oapv_bitb_t *bitb, oapv_frms_t *ofrms, oapvm_t mid
             ofrms->frm[frame_cnt].group_id = pbuh.group_id;
             stat->frm_size[frame_cnt] = pbu_size + 4 /* byte size of 'pbu_size' syntax */;
             frame_cnt++;
+
+            oapv_assert_g(OAPV_SUCCEEDED(ret_thread), ERR);
         }
         else if(pbuh.pbu_type == OAPV_PBU_TYPE_METADATA) {
             ret = oapvd_vlc_metadata(bs, pbu_size, mid, pbuh.group_id);

--- a/src/oapv.c
+++ b/src/oapv.c
@@ -2033,7 +2033,7 @@ int oapvd_decode(oapvd_t did, oapv_bitb_t *bitb, oapv_frms_t *ofrms, oapvm_t mid
             stat->frm_size[frame_cnt] = pbu_size + 4 /* byte size of 'pbu_size' syntax */;
             frame_cnt++;
 
-            oapv_assert_g(OAPV_SUCCEEDED(ret_thread), ERR);
+            oapv_assert_gv(OAPV_SUCCEEDED(ret_thread), ret, ret_thread, ERR);
         }
         else if(pbuh.pbu_type == OAPV_PBU_TYPE_METADATA) {
             ret = oapvd_vlc_metadata(bs, pbu_size, mid, pbuh.group_id);

--- a/src/oapv.c
+++ b/src/oapv.c
@@ -2025,7 +2025,7 @@ int oapvd_decode(oapvd_t did, oapv_bitb_t *bitb, oapv_frms_t *ofrms, oapvm_t mid
             if(ret == OAPV_OK && ctx->use_frm_hash) {
                 oapv_imgb_set_md5(ctx->imgb);
             }
-            ret = dec_frm_finish(ctx); // FIX-ME
+            ret = dec_frm_finish(ctx);
             oapv_assert_g(OAPV_SUCCEEDED(ret), ERR);
 
             ofrms->frm[frame_cnt].pbu_type = pbuh.pbu_type;
@@ -2033,6 +2033,7 @@ int oapvd_decode(oapvd_t did, oapv_bitb_t *bitb, oapv_frms_t *ofrms, oapvm_t mid
             stat->frm_size[frame_cnt] = pbu_size + 4 /* byte size of 'pbu_size' syntax */;
             frame_cnt++;
 
+            /* here, check return values of each thread */
             oapv_assert_gv(OAPV_SUCCEEDED(ret_thread), ret, ret_thread, ERR);
         }
         else if(pbuh.pbu_type == OAPV_PBU_TYPE_METADATA) {

--- a/src/oapv_vlc.c
+++ b/src/oapv_vlc.c
@@ -650,6 +650,8 @@ static int dec_vlc_read_kparam0(oapv_bs_t *bs)
             k++;
         }
     }
+    oapv_assert_rv(k < 32, -1); /* prevent too large (impossible) k value */
+
     if(k > 0) {
         symbol += ((u32)0xFFFFFFFF) >> (32 - k);
 
@@ -736,6 +738,9 @@ static int dec_vlc_read(oapv_bs_t *bs, int k)
             }
         }
     }
+
+    oapv_assert_rv(k < 32, -1); /* prevent too large (impossible) k value */
+
     if(k > 0) {
         while(bs->leftbits < k) {
             symbol += bs->code >> (64 - k);
@@ -857,6 +862,8 @@ int oapvd_vlc_ac_coef(oapv_bs_t *bs, s16 *coef, int *kparam_ac)
         else {
             run = dec_vlc_read(bs, k_run);
         }
+
+        oapv_assert_rv(run >= 0, OAPV_ERR_MALFORMED_BITSTREAM);
 
         // here, no need to set 'zero-run' in coef; it's already initialized to zero.
 


### PR DESCRIPTION
Added protection code in case of large (impossible) k value caused by Fuzz testing