### PR TITLE
fix: the argument parsing function copies a command-... in...

### DIFF
--- a/app/oapv_app_args.h
+++ b/app/oapv_app_args.h
@@ -57,6 +57,7 @@ typedef struct args_opt {
     int   val_type;                    /* value type */
     int   flag;                        /* flag to setting or not */
     void *val;                         /* actual value */
+    int   val_len;                     /* buffer length for string values */
     char  desc[1024];                   /* description of option */
 } args_opt_t;
 
@@ -124,7 +125,10 @@ static int args_read_value(args_opt_t *ops, const char *argv)
         break;
 
     case ARGS_VAL_TYPE_STRING:
-        strcpy((char *)ops->val, argv);
+        if(ops->val_len > 0) {
+            strncpy((char *)ops->val, argv, (size_t)(ops->val_len - 1));
+            ((char *)ops->val)[ops->val_len - 1] = '\0';
+        }
         break;
 
     default:
@@ -314,7 +318,7 @@ ERR:
     return -1;
 }
 
-static int args_set_variable_by_key_long(args_opt_t *opts, char *key_long, void *var)
+static int _args_set_variable_by_key_long(args_opt_t *opts, char *key_long, void *var, int val_len)
 {
     int   idx;
     char  buf[ARGS_MAX_KEY_LONG];
@@ -337,8 +341,12 @@ static int args_set_variable_by_key_long(args_opt_t *opts, char *key_long, void 
     if(idx < 0)
         return -1;
     opts[idx].val = var;
+    opts[idx].val_len = val_len;
     return 0;
 }
+
+#define args_set_variable_by_key_long(opts, key_long, var) \
+    _args_set_variable_by_key_long(opts, key_long, (void *)(var), (int)sizeof(var))
 
 static int args_set_variable_by_key(args_opt_t *opts, char *key, void *var)
 {


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `app/oapv_app_args.h`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `app/oapv_app_args.h:127` |

**Description**: The argument parsing function copies a command-line argument string directly into a fixed-size destination buffer (ops->val) using strcpy, which performs no length validation. Because the source string (argv) is entirely attacker-controlled and its length is unbounded, an attacker can supply an argument longer than the allocated destination buffer, overflowing it and overwriting adjacent memory including return addresses, function pointers, or heap metadata.

## Changes
- `app/oapv_app_args.h`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
