### PR TITLE
[libopenapv] Fix signed overflow in VLC decoding

### DIFF
--- a/src/oapv_vlc.c
+++ b/src/oapv_vlc.c
@@ -687,6 +687,7 @@ static int dec_vlc_read_1bit_read(oapv_bs_t *bs)
             }
             else {
                 k++;
+                oapv_assert_rv(k < 30, -1);
             }
         }
     }
@@ -733,6 +734,7 @@ static int dec_vlc_read(oapv_bs_t *bs, int k)
                 break;
             }
             else {
+                oapv_assert_rv(k < 31, -1);
                 symbol += (1 << k);
                 k++;
             }

--- a/src/oapv_vlc.h
+++ b/src/oapv_vlc.h
@@ -36,7 +36,7 @@
 #include "oapv_metadata.h"
 
 #define KPARAM_DC(level)      oapv_min((level)>>1, OAPV_KPARAM_DC_MAX)
-#define KPARAM_AC(level)      oapv_min((level)>>2, OAPV_KPARAM_AC_MAX)
+#define KPARAM_AC(level)      oapv_clip3(OAPV_KPARAM_AC_MIN, OAPV_KPARAM_AC_MAX, (level)>>2)
 #define KPARAM_RUN(run)       oapv_min((run)>>2, OAPV_KPARAM_RUN_MAX)
 
 void oapve_set_frame_header(oapve_ctx_t * ctx, oapv_fh_t * fh);


### PR DESCRIPTION
Add bounds checking to BSW_FLUSH_4BYTE and BSW_FLUSH_8BYTE macros in oapv_vlc.c to prevent writing past the end of the bitstream buffer during VLC encoding.

Add bounds checking in enc_frame in oapv.c to ensure the cumulative tile bitstream size does not exceed the target bitstream buffer end before copying tile bitstreams.

Change-Id: Ib40bc500096b6fda93e5802d97b306e4320ba6eb