### PR TITLE
multiple security and robustness issues and adds release automation

### DIFF
--- a/.github/workflows/sign-release.yml
+++ b/.github/workflows/sign-release.yml
@@ -1,0 +1,37 @@
+name: Sign Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  sign-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6.0.3
+
+      - name: Download release assets
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download ${{ github.event.release.tag_name }} \
+            --dir release-assets \
+            --pattern "*.tar.gz" \
+            --pattern "*.zip" \
+            --pattern "*.deb" \
+            --pattern "*.dmg"
+
+      - name: Generate SHA256SUMS
+        run: |
+          cd release-assets
+          sha256sum * > SHA256SUMS
+          cat SHA256SUMS
+
+      - name: Upload SHA256SUMS to release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ github.event.release.tag_name }} \
+            release-assets/SHA256SUMS \
+            --clobber

--- a/.github/workflows/verify-release-version.yml
+++ b/.github/workflows/verify-release-version.yml
@@ -1,0 +1,47 @@
+name: Verify Release Version
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  verify-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6.0.3
+
+      - name: Extract version from tag
+        id: tag_version
+        run: |
+          TAG="${GITHUB_REF#refs/tags/v}"
+          TAG_VERSION=$(echo "$TAG" | cut -d. -f1-4)
+          echo "version=${TAG_VERSION}" >> $GITHUB_OUTPUT
+          echo "Tag version: ${TAG_VERSION}"
+
+      - name: Extract version from oapv.h
+        id: header_version
+        run: |
+          APISET=$(grep "^#define OAPV_VER_APISET" inc/oapv.h | awk '{print $3}')
+          MAJOR=$(grep "^#define OAPV_VER_MAJOR" inc/oapv.h | awk '{print $3}')
+          MINOR=$(grep "^#define OAPV_VER_MINOR" inc/oapv.h | awk '{print $3}')
+          PATCH=$(grep "^#define OAPV_VER_PATCH" inc/oapv.h | awk '{print $3}')
+          HEADER_VERSION="${APISET}.${MAJOR}.${MINOR}.${PATCH}"
+          echo "version=${HEADER_VERSION}" >> $GITHUB_OUTPUT
+          echo "Header version: ${HEADER_VERSION}"
+
+      - name: Verify versions match
+        run: |
+          TAG_VERSION="${{ steps.tag_version.outputs.version }}"
+          HEADER_VERSION="${{ steps.header_version.outputs.version }}"
+
+          if [ "$TAG_VERSION" != "$HEADER_VERSION" ]; then
+            echo "❌ Version mismatch!"
+            echo "   Release tag: v${TAG_VERSION}"
+            echo "   oapv.h:      ${HEADER_VERSION}"
+            echo ""
+            echo "Please update OAPV_VER_* in inc/oapv.h to match the release tag."
+            exit 1
+          fi
+
+          echo "✅ Versions match: ${TAG_VERSION}"

--- a/app/oapv_app_dec.c
+++ b/app/oapv_app_dec.c
@@ -252,6 +252,10 @@ static int read_bitstream(FILE *fp, unsigned char *bs_buf, int *bs_buf_size)
                     logerr("ERR: Cannot read bitstream!\n");
                     return -1;
                 }
+                if(read_size >= MAX_BS_BUF) {
+                    logerr("ERR: bitstream buffer overflow\n");
+                    return -1;
+                }
                 bs_buf[read_size] = b;
                 read_size++;
                 au_size--;

--- a/src/oapv.c
+++ b/src/oapv.c
@@ -1495,10 +1495,13 @@ static int dec_frm_prepare(oapvd_ctx_t *ctx, oapv_tile_info_t * part, oapv_imgb_
     for(int c = 0; c < imgb->np; c++) {
         int comp_w = aligned_w >> (c > 0 ? get_chroma_sft_w(ctx->fh.fi.chroma_format_idc) : 0);
         int comp_h = aligned_h >> (c > 0 ? get_chroma_sft_h(ctx->fh.fi.chroma_format_idc) : 0);
+        // frame_width/height are signaled in 24 bits, so the required buffer
+        // size can exceed INT_MAX; compute in s64 so the product does not wrap
+        // and let a too-small (int) bsize incorrectly pass the check
         int required_stride = comp_w * byte_depth;
-        int required_bsize = required_stride * comp_h;
+        s64 required_bsize = (s64)required_stride * comp_h;
 
-        if(imgb->bsize[c] < required_bsize) {
+        if((s64)imgb->bsize[c] < required_bsize) {
             return OAPV_ERR_INVALID_ARGUMENT;
         }
     }

--- a/src/oapv_vlc.c
+++ b/src/oapv_vlc.c
@@ -860,6 +860,8 @@ int oapvd_vlc_dc_coef(oapv_bs_t *bs, int *dc_diff, int *kparam_dc)
     abs_dc_diff = dec_vlc_read(bs, *kparam_dc);
     if(abs_dc_diff < 0) // dec_vlc_read error sentinel
         return OAPV_ERR_MALFORMED_BITSTREAM;
+    if(abs_dc_diff > 32767)
+        return OAPV_ERR_MALFORMED_BITSTREAM;
     if(abs_dc_diff) {
         if(bs->leftbits == 0) BSR_FLUSH_1BYTE(bs);
         BSR_READ_1BIT(bs, sign);
@@ -907,6 +909,8 @@ int oapvd_vlc_ac_coef(oapv_bs_t *bs, s16 *coef, int *kparam_ac)
                 }
                 else {
                     run = dec_vlc_read_kparam0(bs);
+                    if(run < 0)
+                        return OAPV_ERR_MALFORMED_BITSTREAM;
                 }
             }
         }
@@ -934,12 +938,20 @@ int oapvd_vlc_ac_coef(oapv_bs_t *bs, s16 *coef, int *kparam_ac)
                 level = 1;
             }
             else {
-                level = dec_vlc_read_1bit_read(bs) + 1;
+                level = dec_vlc_read_1bit_read(bs);
+                if(level < 0)
+                    return OAPV_ERR_MALFORMED_BITSTREAM;
+                level += 1;
             }
         }
         else {
-            level = dec_vlc_read(bs, k_ac) + 1;
+            level = dec_vlc_read(bs, k_ac);
+            if(level < 0)
+                return OAPV_ERR_MALFORMED_BITSTREAM;
+            level += 1;
         }
+        if(level > 32767)
+            return OAPV_ERR_MALFORMED_BITSTREAM;
         k_ac = KPARAM_AC(level);
 
         if(first_ac) {

--- a/src/oapv_vlc.c
+++ b/src/oapv_vlc.c
@@ -739,7 +739,8 @@ static int dec_vlc_read_1bit_read(oapv_bs_t *bs)
 
 static int dec_vlc_read(oapv_bs_t *bs, int k)
 {
-    int symbol;
+    // u32 so accumulation wraps (defined) instead of signed-overflow UB
+    u32 symbol;
     int flag;
     int parse_exp_golomb = 0;
 
@@ -750,7 +751,7 @@ static int dec_vlc_read(oapv_bs_t *bs, int k)
         if(bs->leftbits == 0) BSR_FLUSH_1BYTE(bs);
         BSR_READ_1BIT(bs, flag);
 
-        symbol = (1 + flag) << k;
+        symbol = (u32)(1 + flag) << k;
         parse_exp_golomb = flag;
     }
     else {
@@ -765,7 +766,18 @@ static int dec_vlc_read(oapv_bs_t *bs, int k)
                 break;
             }
             else {
-                symbol += (1 << k);
+                // The APV spec has no (k & 31) here: for a valid bitstream k
+                // stays below 32 so the mask is a no-op. It exists only to
+                // keep the shift count in [0,31] for a malformed stream that
+                // drives k past 31, which would otherwise be shift-count UB.
+                // Such a stream is rejected by the (k < 32) check after the
+                // loop, so the masked value is never used.
+                //
+                // The mask is used instead of an in-loop (k < 32) branch on
+                // purpose: this is the hot coefficient-decoding loop, and an
+                // extra conditional here would add a mispredictable branch and
+                // slow down decoding of every symbol. Masking is branch-free.
+                symbol += 1u << (k & 31);
                 k++;
             }
         }


### PR DESCRIPTION
### Bug Fixes
  - Prevent signed integer overflow in VLC exp-golomb decoding by using unsigned arithmetic
  - Add buffer overflow protection in bitstream reading
  - Validate TransCoeff range in DC and AC coefficient parsing
  - Fix buffer size validation in decoder with s64 casting to prevent overflow

### Release Automation
  - Add GitHub Actions workflow to automatically generate SHA256SUMS for releases
  - Add GitHub Actions workflow to verify release tag version matches oapv.h version numbers

### Issues Resolved
  - Issue #219: Heap buffer overflow in read_bitstream
  - Issue #220: Signed integer overflow in VLC decoding
  - Issue #180: TransCoeff range validation
  - Issue #215: Signed source releases support