### PR TITLE
Add per-frame RC state slots and u64 total_bits fix (from PR #228)

### DIFF
--- a/src/oapv.c
+++ b/src/oapv.c
@@ -1234,7 +1234,7 @@ int oapve_encode(oapve_t eid, oapv_frms_t *ifrms, oapvm_t mid, oapv_bitb_t *bitb
 
         /* Load this frame slot's RC state into the working ctx->rc_param so
          * enc_frame and oapve_rc_update_after_pic operate on per-slot alpha/beta. */
-        int rc_slot = (i < OAPV_MAX_NUM_FRAMES) ? i : (OAPV_MAX_NUM_FRAMES - 1);
+        int rc_slot = oapv_min(i, OAPV_MAX_NUM_FRAMES - 1);
         ctx->rc_param = ctx->rc_param_frm[rc_slot];
 
         // write headers

--- a/src/oapv.c
+++ b/src/oapv.c
@@ -602,6 +602,13 @@ static int enc_ready(oapve_ctx_t *ctx)
 
     ctx->rc_param.alpha = OAPV_RC_ALPHA;
     ctx->rc_param.beta = OAPV_RC_BETA;
+    /* Per-frame-index RC state: each frame slot keeps its own alpha/beta so
+     * the controller adapts per frame index rather than across frames. */
+    for(int i = 0; i < OAPV_MAX_NUM_FRAMES; i++) {
+        oapv_mset(&ctx->rc_param_frm[i], 0, sizeof(oapve_rc_param_t));
+        ctx->rc_param_frm[i].alpha = OAPV_RC_ALPHA;
+        ctx->rc_param_frm[i].beta = OAPV_RC_BETA;
+    }
     ctx->au_bs_fmt = OAPV_CFG_VAL_AU_BS_FMT_RBAU; // default: enable raw bitstream format
 
     return OAPV_OK;
@@ -1225,6 +1232,11 @@ int oapve_encode(oapve_t eid, oapv_frms_t *ifrms, oapvm_t mid, oapv_bitb_t *bitb
         ret = enc_frm_prepare(ctx, &ctx->cdesc.param[i], frm->imgb, (rfrms != NULL) ? rfrms->frm[i].imgb : NULL);
         oapv_assert_rv(OAPV_SUCCEEDED(ret), ret);
 
+        /* Load this frame slot's RC state into the working ctx->rc_param so
+         * enc_frame and oapve_rc_update_after_pic operate on per-slot alpha/beta. */
+        int rc_slot = (i < OAPV_MAX_NUM_FRAMES) ? i : (OAPV_MAX_NUM_FRAMES - 1);
+        ctx->rc_param = ctx->rc_param_frm[rc_slot];
+
         // write headers
         bs_pos_pbu_beg = oapv_bsw_sink(bs);            /* store pbu pos to calculate size */
         DUMP_SAVE(0);
@@ -1233,6 +1245,9 @@ int oapve_encode(oapve_t eid, oapv_frms_t *ifrms, oapvm_t mid, oapv_bitb_t *bitb
         // encode a frame
         ret = enc_frame(ctx, bs);
         oapv_assert_rv(OAPV_SUCCEEDED(ret), ret);
+
+        /* Save the updated RC state back into this slot for the next AU. */
+        ctx->rc_param_frm[rc_slot] = ctx->rc_param;
 
         // rewrite pbu_size
         int pbu_size = ((u8 *)oapv_bsw_sink(bs)) - bs_pos_pbu_beg - 4;

--- a/src/oapv_def.h
+++ b/src/oapv_def.h
@@ -279,6 +279,11 @@ struct oapve_ctx {
     oapv_fh_t                  fh;
     oapve_tile_t               tile[OAPV_MAX_TILES];
     oapve_rc_param_t           rc_param;
+    /* per-frame RC working slots: rc_param is loaded from rc_param_frm[i] at
+     * the start of each frame and saved back after oapve_rc_update_after_pic,
+     * so alpha/beta drift from one frame doesn't pollute the next AU's other
+     * frames. Keyed by frame index in the AU (0 = primary, 1..N = others). */
+    oapve_rc_param_t           rc_param_frm[OAPV_MAX_NUM_FRAMES];
     oapv_tpool_t              *tpool;
     oapv_thread_t              thread_id[OAPV_MAX_THREADS];
     oapv_sync_obj_t            sync_obj;

--- a/src/oapv_rc.c
+++ b/src/oapv_rc.c
@@ -214,9 +214,12 @@ void oapve_rc_update_after_pic(oapve_ctx_t* ctx, double cost)
             num_pixel += (ctx->w * ctx->h) >> (ctx->c_sft[c][0] + ctx->c_sft[c][1]);
         }
 
-        int total_bits = 0;
+        /* total_bits must be u64: a 16k 10-bit 4:2:2 frame at high quality can
+         * exceed INT_MAX bits (~33 MB encoded), which previously wrapped negative
+         * and turned the subsequent log() into NaN, corrupting alpha/beta. */
+        u64 total_bits = 0;
         for (int i = 0; i < ctx->num_tiles; i++) {
-            total_bits += ctx->fh.tile_size[i] * 8;
+            total_bits += (u64)ctx->fh.tile_size[i] * 8;
         }
 
         double ln_bpp = log(pow(cost / (double)num_pixel, OAPV_RC_BETA));


### PR DESCRIPTION
Extract the rate-control-only changes from PR #228 (TMV multi-mip work)
