### PR TITLE
Add per-instance custom memory allocator interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,9 @@ Decoding:
 ## Custom memory allocator
 
 By default the library allocates with the standard C library. An application
-can instead supply its own allocator **per codec instance** through the
-`ops_mem` field of the encoder/decoder descriptor (`oapve_cdesc_t` /
-`oapvd_cdesc_t`). This is useful for integrating with a host memory manager
+can instead supply its own allocator **per instance** through the
+`ops_mem` field of the creation descriptor (`oapve_cdesc_t` / `oapvd_cdesc_t` /
+`oapvm_cdesc_t`). This is useful for integrating with a host memory manager
 (e.g. a game-engine allocator) or for memory tracking. There is no global
 allocator state.
 
@@ -188,6 +188,16 @@ int main(void)
     int err;
     oapve_t eid = oapve_create(&cdesc, &err);
 }
+```
+
+The metadata container takes the same interface through `oapvm_cdesc_t`:
+
+```c
+oapvm_cdesc_t mdesc;
+memset(&mdesc, 0, sizeof(mdesc)); // ops_mem defaults to NULL
+mdesc.ops_mem = &ops;             // opt in to the custom allocator
+
+oapvm_t mid = oapvm_create(&mdesc, &err);
 ```
 
 ## Utility

--- a/README.md
+++ b/README.md
@@ -116,6 +116,80 @@ Decoding:
 
     oapv_app_dec -i encoded.apv -o output.y4m
 
+## Custom memory allocator
+
+By default the library allocates with the standard C library. An application
+can instead supply its own allocator **per codec instance** through the
+`ops_mem` field of the encoder/decoder descriptor (`oapve_cdesc_t` /
+`oapvd_cdesc_t`). This is useful for integrating with a host memory manager
+(e.g. a game-engine allocator) or for memory tracking. There is no global
+allocator state.
+
+The interface is `oapv_ops_mem_t` (declared in `oapv.h`):
+
+```c
+typedef struct oapv_ops_mem {
+    unsigned int magic;   // set to OAPV_OPS_MAGIC_CODE_MEM when used
+    void *(*malloc) (void *udata, unsigned int size);
+    void *(*calloc) (void *udata, unsigned int count, unsigned int size);
+    void *(*realloc)(void *udata, void *ptr, unsigned int size);
+    void  (*free)   (void *udata, void *ptr);
+    void  *udata;         // opaque pointer passed back to every callback
+} oapv_ops_mem_t;
+```
+
+Rules:
+- Provide **all four** function pointers (custom), or **none** — leave
+  `ops_mem` as `NULL` to use the standard C library. A partially-filled
+  interface is rejected with `OAPV_ERR_INVALID_ARGUMENT`.
+- When providing custom allocators, set `magic` to `OAPV_OPS_MAGIC_CODE_MEM`.
+- `udata` is passed unchanged to every callback; the object it points to must
+  stay valid for the lifetime of the codec instance.
+- `free` must accept a `NULL` pointer (like standard `free`).
+- Zero-initialize the descriptor so `ops_mem` defaults to `NULL` when not used.
+
+Example (encoder; the decoder is identical via `oapvd_cdesc_t.ops_mem`):
+
+```c
+static void *my_malloc(void *u, unsigned int s)
+{
+    return my_alloc((MyHeap *)u, s);
+}
+
+static void *my_calloc(void *u, unsigned int c, unsigned int s)
+{
+    return my_zalloc((MyHeap *)u, c, s);
+}
+
+static void *my_realloc(void *u, void *p, unsigned int s)
+{
+    return my_realloc_((MyHeap *)u, p, s);
+}
+
+static void my_free(void *u, void *p)
+{
+    my_free_((MyHeap *)u, p);
+}
+
+int main(void)
+{
+    MyHeap heap = /* ... */;
+    oapv_ops_mem_t ops = {
+        OAPV_OPS_MAGIC_CODE_MEM,
+        my_malloc, my_calloc, my_realloc, my_free,
+        &heap
+    };
+
+    oapve_cdesc_t cdesc;
+    memset(&cdesc, 0, sizeof(cdesc)); // ops_mem defaults to NULL
+    /* ... set other cdesc fields ... */
+    cdesc.ops_mem = &ops;             // opt in to the custom allocator
+
+    int err;
+    oapve_t eid = oapve_create(&cdesc, &err);
+}
+```
+
 ## Utility
 
 ### Graphical APV bitstream parser

--- a/app/oapv_app_dec.c
+++ b/app/oapv_app_dec.c
@@ -423,6 +423,7 @@ int dec_api_set_0(args_var_t *args_var, FILE *fp_bs, int is_y4m)
     oapvd_t          did = NULL;
     oapvm_t          mid = NULL;
     oapvd_cdesc_t    cdesc;
+    oapvm_cdesc_t    mdesc;
     oapv_au_info_t   aui;
     oapvd_stat_t     stat;
     unsigned char   *bs_buf = NULL;
@@ -483,7 +484,8 @@ int dec_api_set_0(args_var_t *args_var, FILE *fp_bs, int is_y4m)
     au_cnt = 0;
 
     /* create metadata container */
-    mid = oapvm_create(&ret);
+    memset(&mdesc, 0, sizeof(oapvm_cdesc_t));
+    mid = oapvm_create(&mdesc, &ret);
     if(OAPV_FAILED(ret)) {
         logerr("ERR: cannot create OAPV metadata container (err=%d)\n", ret);
         ret = -1;

--- a/app/oapv_app_dec.c
+++ b/app/oapv_app_dec.c
@@ -450,6 +450,9 @@ int dec_api_set_0(args_var_t *args_var, FILE *fp_bs, int is_y4m)
         goto ERR;
     }
 
+    // clear descriptor so unset fields (e.g. ops_mem) default to zero
+    memset(&cdesc, 0, sizeof(oapvd_cdesc_t));
+
     // create decoder
     if(!strcmp(args_var->threads, "auto")){
         cdesc.threads = OAPV_CDESC_THREADS_AUTO;
@@ -802,6 +805,9 @@ int dec_api_set_1(args_var_t *args_var, FILE *fp_bs, int is_y4m)
         ptinfo_in_frm = NULL;
         ptinfo_dec = NULL;
     }
+
+    // clear descriptor so unset fields (e.g. ops_mem) default to zero
+    memset(&cdesc, 0, sizeof(oapvd_cdesc_t));
 
     // create decoder
     if(!strcmp(args_var->threads, "auto")){

--- a/app/oapv_app_enc.c
+++ b/app/oapv_app_enc.c
@@ -875,6 +875,7 @@ int main(int argc, const char **argv)
     oapve_t        id = NULL;
     oapvm_t        mid = NULL;
     oapve_cdesc_t  cdesc;
+    oapvm_cdesc_t  mdesc;
     oapve_param_t *param = NULL;
     oapv_bitb_t    bitb;
     oapve_stat_t   stat;
@@ -1076,7 +1077,8 @@ int main(int argc, const char **argv)
     }
 
     /* create metadata handler */
-    mid = oapvm_create(&ret);
+    memset(&mdesc, 0, sizeof(oapvm_cdesc_t));
+    mid = oapvm_create(&mdesc, &ret);
     if(mid == NULL || OAPV_FAILED(ret)) {
         logerr("ERR: cannot create OAPV metadata handler\n");
         ret = -1;

--- a/inc/oapv.h
+++ b/inc/oapv.h
@@ -730,13 +730,22 @@ struct oapvm_payload {
 };
 
 /*****************************************************************************
+ * description for metadata container creation
+ *****************************************************************************/
+typedef struct oapvm_cdesc oapvm_cdesc_t;
+struct oapvm_cdesc {
+    // custom memory allocator interface, or NULL for standard C library
+    const oapv_ops_mem_t *ops_mem;
+};
+
+/*****************************************************************************
  * interface for metadata container
  *****************************************************************************/
 /* instance identifier for OAPV metadata container*/
 typedef void       *oapvm_t;
 
 /* main APIs *****************************************************************/
-OAPV_EXPORT oapvm_t oapvm_create(int *err);
+OAPV_EXPORT oapvm_t oapvm_create(oapvm_cdesc_t *cdesc, int *err);
 OAPV_EXPORT void oapvm_delete(oapvm_t mid);
 OAPV_EXPORT int oapvm_set(oapvm_t mid, int group_id, int type, void *data, int size);
 OAPV_EXPORT int oapvm_get(oapvm_t mid, int group_id, int type, void **data, int *size, unsigned char *uuid);

--- a/inc/oapv.h
+++ b/inc/oapv.h
@@ -641,6 +641,29 @@ struct oapve_param {
 #define OAPV_CDESC_THREADS_AUTO          0
 
 /*****************************************************************************
+ * memory operations interface
+ *
+ * Custom allocator for a single codec instance, supplied through the codec
+ * descriptor (cdesc) at creation time and copied into the codec context;
+ * there is no process-global allocator state. When a function pointer is
+ * NULL the library uses the corresponding standard C routine. 'udata' is an
+ * opaque, caller-owned pointer passed back to every callback (e.g. the host
+ * allocator/arena object); it must stay valid for the codec's lifetime.
+ *****************************************************************************/
+#define OAPV_OPS_MAGIC_CODE_MEM 0x30504D4D /* 0PMM */
+
+typedef struct oapv_ops_mem oapv_ops_mem_t;
+struct oapv_ops_mem {
+    // set to OAPV_OPS_MAGIC_CODE_MEM for custom allocators; 0 => libc
+    unsigned int magic;
+    void *(*malloc)(void *udata, unsigned int size);
+    void *(*calloc)(void *udata, unsigned int count, unsigned int size);
+    void *(*realloc)(void *udata, void *ptr, unsigned int size);
+    void (*free)(void *udata, void *ptr);
+    void *udata;
+};
+
+/*****************************************************************************
  * description for encoder creation
  *****************************************************************************/
 typedef struct oapve_cdesc oapve_cdesc_t;
@@ -653,6 +676,8 @@ struct oapve_cdesc {
     int           threads;
     // encoding parameters
     oapve_param_t param[OAPV_MAX_NUM_FRAMES];
+    // custom memory allocator interface, or NULL for standard C library
+    const oapv_ops_mem_t *ops_mem;
 };
 
 /*****************************************************************************
@@ -675,6 +700,8 @@ typedef struct oapvd_cdesc oapvd_cdesc_t;
 struct oapvd_cdesc {
     // max number of threads (or OAPV_CDESC_THREADS_AUTO for auto-assignment)
     int threads;
+    // custom memory allocator interface, or NULL for standard C library
+    const oapv_ops_mem_t *ops_mem;
 };
 
 /*****************************************************************************

--- a/src/oapv.c
+++ b/src/oapv.c
@@ -582,13 +582,13 @@ static int enc_ready(oapve_ctx_t *ctx)
     }
 
     // get the context synchronization handle
-    ctx->sync_obj = oapv_tpool_sync_obj_create();
+    ctx->sync_obj = oapv_tpool_sync_obj_create(&ctx->ops_mem);
     oapv_assert_gv(ctx->sync_obj != NULL, ret, OAPV_ERR_UNKNOWN, ERR);
 
     if(ctx->threads >= 1) {
         ctx->tpool = oapv_ops_malloc(ctx, sizeof(oapv_tpool_t));
         oapv_assert_gv(ctx->tpool != NULL, ret, OAPV_ERR_OUT_OF_MEMORY, ERR);
-        oapv_tpool_init(ctx->tpool, ctx->threads);
+        oapv_tpool_init(ctx->tpool, &ctx->ops_mem, ctx->threads);
         for(int i = 0; i < ctx->threads; i++) {
             ctx->thread_id[i] = ctx->tpool->create(ctx->tpool, i);
             oapv_assert_gv(ctx->thread_id[i] != NULL, ret, OAPV_ERR_UNKNOWN, ERR);
@@ -1843,13 +1843,13 @@ static int dec_ready(oapvd_ctx_t *ctx)
     }
 
     // get the context synchronization handle
-    ctx->sync_obj = oapv_tpool_sync_obj_create();
+    ctx->sync_obj = oapv_tpool_sync_obj_create(&ctx->ops_mem);
     oapv_assert_gv(ctx->sync_obj != NULL, ret, OAPV_ERR_UNKNOWN, ERR);
 
     if(ctx->threads >= 2) {
         ctx->tpool = oapv_ops_malloc(ctx, sizeof(oapv_tpool_t));
         oapv_assert_gv(ctx->tpool != NULL, ret, OAPV_ERR_OUT_OF_MEMORY, ERR);
-        oapv_tpool_init(ctx->tpool, ctx->threads - 1);
+        oapv_tpool_init(ctx->tpool, &ctx->ops_mem, ctx->threads - 1);
         for(i = 0; i < ctx->threads - 1; i++) {
             ctx->thread_id[i] = ctx->tpool->create(ctx->tpool, i);
             oapv_assert_gv(ctx->thread_id[i] != NULL, ret, OAPV_ERR_UNKNOWN, ERR);

--- a/src/oapv.c
+++ b/src/oapv.c
@@ -175,32 +175,6 @@ static oapve_ctx_t *enc_id_to_ctx(oapve_t id)
     return ctx;
 }
 
-/* allocate/free through the instance's resolved memory interface */
-#define oapv_ops_malloc(ctx, size) \
-    ((ctx)->ops_mem.malloc((ctx)->ops_mem.udata, (size)))
-#define oapv_ops_free(ctx, ptr) \
-    ((ctx)->ops_mem.free((ctx)->ops_mem.udata, (ptr)))
-
-static int set_ops_mem(oapv_ops_mem_t *dst, const oapv_ops_mem_t *src)
-{
-    int nset;
-    if(src == NULL) {
-        oapv_ops_mem_default(dst);
-        return OAPV_OK;
-    }
-    nset = (src->malloc != NULL) + (src->calloc != NULL) +
-           (src->realloc != NULL) + (src->free != NULL);
-    if(nset == 0) {
-        oapv_ops_mem_default(dst);
-        return OAPV_OK;
-    }
-    if(nset == 4 && src->magic == OAPV_OPS_MAGIC_CODE_MEM) {
-        *dst = *src;
-        return OAPV_OK;
-    }
-    return OAPV_ERR_INVALID_ARGUMENT;
-}
-
 static oapve_ctx_t *enc_ctx_alloc(const oapv_ops_mem_t *ops)
 {
     oapve_ctx_t *ctx;
@@ -1177,7 +1151,7 @@ oapve_t oapve_create(oapve_cdesc_t *cdesc, int *err)
         return NULL;
     }
 
-    ret = set_ops_mem(&ops, cdesc->ops_mem);
+    ret = oapv_ops_mem_set(&ops, cdesc->ops_mem);
     if(ret != OAPV_OK) {
         if(err) *err = ret;
         return NULL;
@@ -1935,7 +1909,7 @@ oapvd_t oapvd_create(oapvd_cdesc_t *cdesc, int *err)
         return NULL;
     }
 
-    ret = set_ops_mem(&ops, cdesc->ops_mem);
+    ret = oapv_ops_mem_set(&ops, cdesc->ops_mem);
     if(ret != OAPV_OK) {
         if(err) *err = ret;
         return NULL;

--- a/src/oapv.c
+++ b/src/oapv.c
@@ -175,24 +175,51 @@ static oapve_ctx_t *enc_id_to_ctx(oapve_t id)
     return ctx;
 }
 
-static oapve_ctx_t *enc_ctx_alloc(void)
+/* allocate/free through the instance's resolved memory interface */
+#define oapv_ops_malloc(ctx, size) \
+    ((ctx)->ops_mem.malloc((ctx)->ops_mem.udata, (size)))
+#define oapv_ops_free(ctx, ptr) \
+    ((ctx)->ops_mem.free((ctx)->ops_mem.udata, (ptr)))
+
+static int set_ops_mem(oapv_ops_mem_t *dst, const oapv_ops_mem_t *src)
+{
+    int nset;
+    if(src == NULL) {
+        oapv_ops_mem_default(dst);
+        return OAPV_OK;
+    }
+    nset = (src->malloc != NULL) + (src->calloc != NULL) +
+           (src->realloc != NULL) + (src->free != NULL);
+    if(nset == 0) {
+        oapv_ops_mem_default(dst);
+        return OAPV_OK;
+    }
+    if(nset == 4 && src->magic == OAPV_OPS_MAGIC_CODE_MEM) {
+        *dst = *src;
+        return OAPV_OK;
+    }
+    return OAPV_ERR_INVALID_ARGUMENT;
+}
+
+static oapve_ctx_t *enc_ctx_alloc(const oapv_ops_mem_t *ops)
 {
     oapve_ctx_t *ctx;
-    ctx = (oapve_ctx_t *)oapv_malloc_fast(sizeof(oapve_ctx_t));
+    ctx = (oapve_ctx_t *)ops->malloc(ops->udata, sizeof(oapve_ctx_t));
     oapv_assert_rv(ctx, NULL);
     oapv_mset_x64a(ctx, 0, sizeof(oapve_ctx_t));
+    ctx->ops_mem = *ops;
     return ctx;
 }
 
 static void enc_ctx_free(oapve_ctx_t *ctx)
 {
-    oapv_mfree_fast(ctx);
+    ctx->ops_mem.free(ctx->ops_mem.udata, ctx);
 }
 
-static oapve_core_t *enc_core_alloc()
+static oapve_core_t *enc_core_alloc(oapve_ctx_t *ctx)
 {
     oapve_core_t *core;
-    core = (oapve_core_t *)oapv_malloc_fast(sizeof(oapve_core_t));
+    core = (oapve_core_t *)oapv_ops_malloc(ctx, sizeof(oapve_core_t));
 
     oapv_assert_rv(core, NULL);
     oapv_mset_x64a(core, 0, sizeof(oapve_core_t));
@@ -200,9 +227,9 @@ static oapve_core_t *enc_core_alloc()
     return core;
 }
 
-static void enc_core_free(oapve_core_t *core)
+static void enc_core_free(oapve_ctx_t *ctx, oapve_core_t *core)
 {
-    oapv_mfree_fast(core);
+    oapv_ops_free(ctx, core);
 }
 
 static int enc_core_init(oapve_core_t *core, oapve_ctx_t *ctx, int tile_idx, int thread_idx)
@@ -544,7 +571,7 @@ static void enc_flush(oapve_ctx_t *ctx)
             }
             // deinitialize the tc
             oapv_tpool_deinit(ctx->tpool);
-            oapv_mfree_fast(ctx->tpool);
+            oapv_ops_free(ctx, ctx->tpool);
             ctx->tpool = NULL;
         }
     }
@@ -553,11 +580,11 @@ static void enc_flush(oapve_ctx_t *ctx)
         oapv_tpool_sync_obj_delete(&ctx->sync_obj);
     }
     for(int i = 0; i < ctx->threads; i++) {
-        enc_core_free(ctx->core[i]);
+        enc_core_free(ctx, ctx->core[i]);
         ctx->core[i] = NULL;
     }
 
-    oapv_mfree_fast(ctx->tile[0].bs_buf);
+    oapv_ops_free(ctx, ctx->tile[0].bs_buf);
 }
 
 static int enc_ready(oapve_ctx_t *ctx)
@@ -570,7 +597,7 @@ static int enc_ready(oapve_ctx_t *ctx)
     oapv_assert_g(ret == OAPV_OK, ERR);
 
     for(int i = 0; i < ctx->threads; i++) {
-        core = enc_core_alloc();
+        core = enc_core_alloc(ctx);
         oapv_assert_gv(core != NULL, ret, OAPV_ERR_OUT_OF_MEMORY, ERR);
         ctx->core[i] = core;
     }
@@ -585,7 +612,7 @@ static int enc_ready(oapve_ctx_t *ctx)
     oapv_assert_gv(ctx->sync_obj != NULL, ret, OAPV_ERR_UNKNOWN, ERR);
 
     if(ctx->threads >= 1) {
-        ctx->tpool = oapv_malloc(sizeof(oapv_tpool_t));
+        ctx->tpool = oapv_ops_malloc(ctx, sizeof(oapv_tpool_t));
         oapv_assert_gv(ctx->tpool != NULL, ret, OAPV_ERR_OUT_OF_MEMORY, ERR);
         oapv_tpool_init(ctx->tpool, ctx->threads);
         for(int i = 0; i < ctx->threads; i++) {
@@ -597,7 +624,7 @@ static int enc_ready(oapve_ctx_t *ctx)
     for(int i = 0; i < OAPV_MAX_TILES; i++) {
         ctx->tile[i].stat = ENC_TILE_STAT_NOT_ENCODED;
     }
-    ctx->tile[0].bs_buf = (u8 *)oapv_malloc(ctx->cdesc.max_bs_buf_size);
+    ctx->tile[0].bs_buf = (u8 *)oapv_ops_malloc(ctx, ctx->cdesc.max_bs_buf_size);
     oapv_assert_gv(ctx->tile[0].bs_buf, ret, OAPV_ERR_UNKNOWN, ERR);
 
     ctx->rc_param.alpha = OAPV_RC_ALPHA;
@@ -1137,6 +1164,7 @@ oapve_t oapve_create(oapve_cdesc_t *cdesc, int *err)
 {
     oapve_ctx_t *ctx;
     int          ret;
+    oapv_ops_mem_t ops;
 
     DUMP_CREATE(1);
 
@@ -1149,8 +1177,14 @@ oapve_t oapve_create(oapve_cdesc_t *cdesc, int *err)
         return NULL;
     }
 
+    ret = set_ops_mem(&ops, cdesc->ops_mem);
+    if(ret != OAPV_OK) {
+        if(err) *err = ret;
+        return NULL;
+    }
+
     /* memory allocation for ctx and core structure */
-    ctx = (oapve_ctx_t *)enc_ctx_alloc();
+    ctx = (oapve_ctx_t *)enc_ctx_alloc(&ops);
     if(ctx != NULL) {
         oapv_mcpy(&ctx->cdesc, cdesc, sizeof(oapve_cdesc_t));
         ret = enc_platform_init(ctx);
@@ -1404,28 +1438,29 @@ static oapvd_ctx_t *dec_id_to_ctx(oapvd_t id)
     return ctx;
 }
 
-static oapvd_ctx_t *dec_ctx_alloc(void)
+static oapvd_ctx_t *dec_ctx_alloc(const oapv_ops_mem_t *ops)
 {
     oapvd_ctx_t *ctx;
 
-    ctx = (oapvd_ctx_t *)oapv_malloc_fast(sizeof(oapvd_ctx_t));
+    ctx = (oapvd_ctx_t *)ops->malloc(ops->udata, sizeof(oapvd_ctx_t));
 
     oapv_assert_rv(ctx != NULL, NULL);
     oapv_mset_x64a(ctx, 0, sizeof(oapvd_ctx_t));
+    ctx->ops_mem = *ops;
 
     return ctx;
 }
 
 static void dec_ctx_free(oapvd_ctx_t *ctx)
 {
-    oapv_mfree_fast(ctx);
+    ctx->ops_mem.free(ctx->ops_mem.udata, ctx);
 }
 
-static oapvd_core_t *dec_core_alloc(void)
+static oapvd_core_t *dec_core_alloc(oapvd_ctx_t *ctx)
 {
     oapvd_core_t *core;
 
-    core = (oapvd_core_t *)oapv_malloc_fast(sizeof(oapvd_core_t));
+    core = (oapvd_core_t *)oapv_ops_malloc(ctx, sizeof(oapvd_core_t));
 
     oapv_assert_rv(core, NULL);
     oapv_mset_x64a(core, 0, sizeof(oapvd_core_t));
@@ -1433,9 +1468,9 @@ static oapvd_core_t *dec_core_alloc(void)
     return core;
 }
 
-static void dec_core_free(oapvd_core_t *core)
+static void dec_core_free(oapvd_ctx_t *ctx, oapvd_core_t *core)
 {
-    oapv_mfree_fast(core);
+    oapv_ops_free(ctx, core);
 }
 
 static int dec_block(oapvd_ctx_t *ctx, oapvd_core_t *core, int log2_w, int log2_h, int c)
@@ -1792,7 +1827,7 @@ static void dec_flush(oapvd_ctx_t *ctx)
             }
             // deinitialize the tpool
             oapv_tpool_deinit(ctx->tpool);
-            oapv_mfree(ctx->tpool);
+            oapv_ops_free(ctx, ctx->tpool);
             ctx->tpool = NULL;
         }
     }
@@ -1802,7 +1837,7 @@ static void dec_flush(oapvd_ctx_t *ctx)
     }
 
     for(int i = 0; i < ctx->threads; i++) {
-        dec_core_free(ctx->core[i]);
+        dec_core_free(ctx, ctx->core[i]);
     }
 }
 
@@ -1822,7 +1857,7 @@ static int dec_ready(oapvd_ctx_t *ctx)
     if(ctx->core[0] == NULL) {
         // create cores
         for(i = 0; i < ctx->threads; i++) {
-            ctx->core[i] = dec_core_alloc();
+            ctx->core[i] = dec_core_alloc(ctx);
             oapv_assert_gv(ctx->core[i], ret, OAPV_ERR_OUT_OF_MEMORY, ERR);
             ctx->core[i]->ctx = ctx;
         }
@@ -1838,7 +1873,7 @@ static int dec_ready(oapvd_ctx_t *ctx)
     oapv_assert_gv(ctx->sync_obj != NULL, ret, OAPV_ERR_UNKNOWN, ERR);
 
     if(ctx->threads >= 2) {
-        ctx->tpool = oapv_malloc(sizeof(oapv_tpool_t));
+        ctx->tpool = oapv_ops_malloc(ctx, sizeof(oapv_tpool_t));
         oapv_assert_gv(ctx->tpool != NULL, ret, OAPV_ERR_OUT_OF_MEMORY, ERR);
         oapv_tpool_init(ctx->tpool, ctx->threads - 1);
         for(i = 0; i < ctx->threads - 1; i++) {
@@ -1886,6 +1921,7 @@ oapvd_t oapvd_create(oapvd_cdesc_t *cdesc, int *err)
 {
     oapvd_ctx_t *ctx;
     int          ret;
+    oapv_ops_mem_t ops;
 
     DUMP_CREATE(0);
     ctx = NULL;
@@ -1899,8 +1935,14 @@ oapvd_t oapvd_create(oapvd_cdesc_t *cdesc, int *err)
         return NULL;
     }
 
+    ret = set_ops_mem(&ops, cdesc->ops_mem);
+    if(ret != OAPV_OK) {
+        if(err) *err = ret;
+        return NULL;
+    }
+
     /* memory allocation for ctx and core structure */
-    ctx = (oapvd_ctx_t *)dec_ctx_alloc();
+    ctx = (oapvd_ctx_t *)dec_ctx_alloc(&ops);
     oapv_assert_gv(ctx != NULL, ret, OAPV_ERR_OUT_OF_MEMORY, ERR);
     oapv_mcpy(&ctx->cdesc, cdesc, sizeof(oapvd_cdesc_t));
 

--- a/src/oapv_def.h
+++ b/src/oapv_def.h
@@ -272,6 +272,7 @@ struct oapve_ctx {
     u32                        magic; // magic code
     oapve_t                    id;    // identifier
     oapve_cdesc_t              cdesc;
+    oapv_ops_mem_t             ops_mem; // effective memory allocator
     oapve_core_t              *core[OAPV_MAX_THREADS];
     oapv_imgb_t               *imgb_i;
     oapv_imgb_t               *imgb_r;
@@ -390,6 +391,7 @@ struct oapvd_ctx {
     u32                     magic; // magic code
     oapvd_t                 id;    // identifier
     oapvd_cdesc_t           cdesc;
+    oapv_ops_mem_t          ops_mem; // effective memory allocator
     oapvd_core_t           *core[OAPV_MAX_THREADS];
     oapv_bs_t               bs;
     oapv_imgb_t            *imgb;

--- a/src/oapv_metadata.c
+++ b/src/oapv_metadata.c
@@ -32,7 +32,7 @@
 #include "oapv_def.h"
 #include "oapv_metadata.h"
 
-static oapvm_ctx_t *meta_id_to_ctx(oapvm_t id)
+oapvm_ctx_t *oapvm_id_to_ctx(oapvm_t id)
 {
     oapvm_ctx_t *ctx;
     oapv_assert_rv(id, NULL);
@@ -101,7 +101,7 @@ static oapv_mdp_t *meta_md_find_mdp_with_prev(oapv_md_t *md, int type, unsigned 
     return (type == OAPV_METADATA_USER_DEFINED) ? meta_mdp_find_ud(md, uuid, prev_mdp) : meta_mdp_find_non_ud(md, type, prev_mdp);
 }
 
-static int meta_rm_mdp(oapv_md_t *md, int mdt, unsigned char *uuid)
+static int meta_rm_mdp(oapvm_ctx_t *ctx, oapv_md_t *md, int mdt, unsigned char *uuid)
 {
     oapv_mdp_t *mdp, *mdp_prev;
     mdp = meta_md_find_mdp_with_prev(md, mdt, uuid, &mdp_prev);
@@ -113,8 +113,8 @@ static int meta_rm_mdp(oapv_md_t *md, int mdt, unsigned char *uuid)
         mdp_prev->next = mdp->next;
     }
 
-    oapv_mfree(mdp->pld_data);
-    oapv_mfree(mdp);
+    oapv_ops_free(ctx, mdp->pld_data);
+    oapv_ops_free(ctx, mdp);
     md->mdp_num--;
     return OAPV_OK;
 }
@@ -170,14 +170,14 @@ static int meta_verify_mdp_data(int type, int size, u8 *data)
     return OAPV_OK;
 }
 
-static void meta_free_md(oapv_md_t *md)
+static void meta_free_md(oapvm_ctx_t *ctx, oapv_md_t *md)
 {
     oapv_mdp_t *mdp = md->md_payload;
     while(mdp != NULL) {
-        oapv_mfree(mdp->pld_data);
+        oapv_ops_free(ctx, mdp->pld_data);
         oapv_mdp_t *mdp_t = mdp;
         mdp = mdp->next;
-        oapv_mfree(mdp_t);
+        oapv_ops_free(ctx, mdp_t);
     }
 }
 
@@ -282,7 +282,7 @@ int oapvm_set(oapvm_t mid, int group_id, int type, void *data, int size)
     int          ret = OAPV_OK;
     u8          *uuid = NULL;
 
-    oapvm_ctx_t *ctx = meta_id_to_ctx(mid);
+    oapvm_ctx_t *ctx = oapvm_id_to_ctx(mid);
     oapv_assert_rv(ctx, OAPV_ERR_INVALID_ARGUMENT);
     oapv_assert_rv((data != NULL && size > 0) || (data == NULL && size == 0), OAPV_ERR_INVALID_ARGUMENT);
 
@@ -294,7 +294,7 @@ int oapvm_set(oapvm_t mid, int group_id, int type, void *data, int size)
     }
 
     if(size > 0) {
-        pld_data_new = oapv_malloc(size);
+        pld_data_new = oapv_ops_malloc(ctx, size);
         oapv_assert_rv(pld_data_new != NULL, OAPV_ERR_OUT_OF_MEMORY);
         oapv_mcpy(pld_data_new, data, size);
     }
@@ -314,7 +314,7 @@ int oapvm_set(oapvm_t mid, int group_id, int type, void *data, int size)
 
     oapv_mdp_t *mdp_t = meta_find_mdp(md, type, uuid);
     if(mdp_t == NULL) { // add new one
-        mdp_new = oapv_malloc(sizeof(oapv_mdp_t));
+        mdp_new = oapv_ops_malloc(ctx, sizeof(oapv_mdp_t));
         oapv_assert_gv(mdp_new != NULL, ret, OAPV_ERR_OUT_OF_MEMORY, ERR);
         mdp_new->pld_size = size;
         mdp_new->pld_type = type;
@@ -326,22 +326,22 @@ int oapvm_set(oapvm_t mid, int group_id, int type, void *data, int size)
     }
     else { // replace the exist one
         mdp_t->pld_size = size;
-        oapv_mfree(mdp_t->pld_data);
+        oapv_ops_free(ctx, mdp_t->pld_data);
         mdp_t->pld_data = pld_data_new;
     }
     return OAPV_OK;
 
 ERR:
     if(mdp_new)
-        oapv_mfree(mdp_new);
+        oapv_ops_free(ctx, mdp_new);
     if(pld_data_new)
-        oapv_mfree(pld_data_new);
+        oapv_ops_free(ctx, pld_data_new);
     return ret;
 }
 
 int oapvm_get(oapvm_t mid, int group_id, int type, void **data, int *size, unsigned char *uuid)
 {
-    oapvm_ctx_t *ctx = meta_id_to_ctx(mid);
+    oapvm_ctx_t *ctx = oapvm_id_to_ctx(mid);
     oapv_assert_rv(ctx, OAPV_ERR_INVALID_ARGUMENT);
     oapv_assert_rv(data != NULL && size != NULL, OAPV_ERR_INVALID_ARGUMENT);
     // user-defined lookup compares a 16-byte uuid; it must be provided
@@ -361,13 +361,13 @@ ERR:
 
 int oapvm_rem(oapvm_t mid, int group_id, int type, unsigned char *uuid)
 {
-    oapvm_ctx_t *ctx = meta_id_to_ctx(mid);
+    oapvm_ctx_t *ctx = oapvm_id_to_ctx(mid);
     oapv_assert_rv(ctx, OAPV_ERR_INVALID_ARGUMENT);
     // user-defined lookup compares a 16-byte uuid; it must be provided
     oapv_assert_rv(type != OAPV_METADATA_USER_DEFINED || uuid != NULL, OAPV_ERR_INVALID_ARGUMENT);
     oapv_md_t   *md = meta_find_md(ctx, group_id);
     oapv_assert_g(md != NULL, ERR);
-    return meta_rm_mdp(md, type, uuid);
+    return meta_rm_mdp(ctx, md, type, uuid);
 
 ERR:
     return OAPV_ERR_NOT_FOUND;
@@ -391,7 +391,7 @@ ERR:
 
 int oapvm_get_all(oapvm_t mid, oapvm_payload_t *pld, int *num_plds)
 {
-    oapvm_ctx_t *ctx = meta_id_to_ctx(mid);
+    oapvm_ctx_t *ctx = oapvm_id_to_ctx(mid);
     oapv_assert_rv(ctx, OAPV_ERR_INVALID_ARGUMENT);
     oapv_assert_rv(num_plds != NULL, OAPV_ERR_INVALID_ARGUMENT);
     if(pld == NULL) {
@@ -429,35 +429,70 @@ int oapvm_get_all(oapvm_t mid, oapvm_payload_t *pld, int *num_plds)
 
 void oapvm_rem_all(oapvm_t mid)
 {
-    oapvm_ctx_t *ctx = meta_id_to_ctx(mid);
+    oapvm_ctx_t *ctx = oapvm_id_to_ctx(mid);
     oapv_assert_r(ctx != NULL);
     for(int i = 0; i < ctx->num; i++) {
-        meta_free_md(&ctx->md_arr[i]);
+        meta_free_md(ctx, &ctx->md_arr[i]);
         oapv_mset(&ctx->md_arr[i], 0, sizeof(oapv_md_t));
     }
     ctx->num = 0;
 }
 
-oapvm_t oapvm_create(int *err)
+static oapvm_ctx_t *meta_ctx_alloc(const oapv_ops_mem_t *ops)
 {
     oapvm_ctx_t *ctx;
-    ctx = oapv_malloc(sizeof(oapvm_ctx_t));
+
+    ctx = (oapvm_ctx_t *)ops->malloc(ops->udata, sizeof(oapvm_ctx_t));
+
+    oapv_assert_rv(ctx != NULL, NULL);
+    oapv_mset(ctx, 0, sizeof(oapvm_ctx_t));
+    ctx->ops_mem = *ops;
+
+    return ctx;
+}
+
+static void meta_ctx_free(oapvm_ctx_t *ctx)
+{
+    ctx->ops_mem.free(ctx->ops_mem.udata, ctx);
+}
+
+oapvm_t oapvm_create(oapvm_cdesc_t *cdesc, int *err)
+{
+    oapvm_ctx_t   *ctx;
+    int            ret;
+    oapv_ops_mem_t ops;
+
+    if(cdesc == NULL) {
+        if(err) *err = OAPV_ERR_INVALID_ARGUMENT;
+        return NULL;
+    }
+
+    ret = oapv_ops_mem_set(&ops, cdesc->ops_mem);
+    if(ret != OAPV_OK) {
+        if(err) *err = ret;
+        return NULL;
+    }
+
+    ctx = meta_ctx_alloc(&ops);
     if(ctx == NULL) {
         if(err) *err = OAPV_ERR_OUT_OF_MEMORY;
         return NULL;
     }
-    oapv_mset(ctx, 0, sizeof(oapvm_ctx_t));
+    oapv_mcpy(&ctx->cdesc, cdesc, sizeof(oapvm_cdesc_t));
 
     ctx->magic = OAPVM_MAGIC_CODE;
+    if(err) {
+        *err = OAPV_OK;
+    }
     return ctx;
 }
 
 void oapvm_delete(oapvm_t mid)
 {
-    oapvm_ctx_t *ctx = meta_id_to_ctx(mid);
+    oapvm_ctx_t *ctx = oapvm_id_to_ctx(mid);
     oapv_assert_r(ctx != NULL);
     for(int i = 0; i < ctx->num; i++) {
-        meta_free_md(&ctx->md_arr[i]);
+        meta_free_md(ctx, &ctx->md_arr[i]);
     }
-    oapv_mfree(ctx);
+    meta_ctx_free(ctx);
 }

--- a/src/oapv_metadata.h
+++ b/src/oapv_metadata.h
@@ -55,10 +55,14 @@ struct oapv_md {
 
 typedef struct oapvm_ctx oapvm_ctx_t;
 struct oapvm_ctx {
-    u32       magic; // magic code
-    oapv_md_t md_arr[OAPV_MAX_NUM_METAS];
-    int       num;
+    u32            magic; // magic code
+    oapvm_cdesc_t  cdesc;
+    oapv_ops_mem_t ops_mem; // effective memory allocator
+    oapv_md_t      md_arr[OAPV_MAX_NUM_METAS];
+    int            num;
 };
+
+oapvm_ctx_t *oapvm_id_to_ctx(oapvm_t id);
 
 /* Filler metadata */
 typedef struct oapv_md_fm oapv_md_fm_t;

--- a/src/oapv_port.c
+++ b/src/oapv_port.c
@@ -30,32 +30,40 @@
  */
 
 #include <stdarg.h>
-#include "oapv_port.h"
+#include "oapv_def.h"
 
-void *oapv_malloc_align32(int size)
+static void *oapv_ops_mem_malloc_libc(void *udata, unsigned int size)
 {
-    void *p = NULL;
-
-    // p variable is covered under ap. It's user rosponsibility to free it using funcion oapv_mfree_align32.
-    p = oapv_malloc(size + 32 + sizeof(void *));
-    if(p) {
-
-#ifdef _IS64BIT // for 64bit CPU
-        void **ap = (void **)(((u64)(p) + 32 + sizeof(void *) - 1) & (~0x1F));
-#else // for 32bit CPU
-        void **ap = (void **)(((u32)(p) + 32 + sizeof(void *) - 1) & (~0x1F));
-#endif
-        ap[-1] = (void *)p;
-        return (void *)ap;
-    }
-    return NULL;
+    (void)udata;
+    return malloc(size);
 }
 
-void oapv_mfree_align32(void *p)
+static void *oapv_ops_mem_calloc_libc(void *udata, unsigned int count, unsigned int size)
 {
-    if(p) {
-        oapv_mfree(((void **)p)[-1]);
-    }
+    (void)udata;
+    return calloc(count, size);
+}
+
+static void *oapv_ops_mem_realloc_libc(void *udata, void *ptr, unsigned int size)
+{
+    (void)udata;
+    return realloc(ptr, size);
+}
+
+static void oapv_ops_mem_free_libc(void *udata, void *ptr)
+{
+    (void)udata;
+    free(ptr);
+}
+
+void oapv_ops_mem_default(oapv_ops_mem_t *dst)
+{
+    dst->magic   = OAPV_OPS_MAGIC_CODE_MEM;
+    dst->malloc  = oapv_ops_mem_malloc_libc;
+    dst->calloc  = oapv_ops_mem_calloc_libc;
+    dst->realloc = oapv_ops_mem_realloc_libc;
+    dst->free    = oapv_ops_mem_free_libc;
+    dst->udata   = NULL;
 }
 
 void oapv_trace0(char *filename, int line, const char *fmt, ...)

--- a/src/oapv_port.c
+++ b/src/oapv_port.c
@@ -32,38 +32,58 @@
 #include <stdarg.h>
 #include "oapv_def.h"
 
-static void *oapv_ops_mem_malloc_libc(void *udata, unsigned int size)
+static void *oapv_ops_mem_alloc_libc(void *udata, unsigned int size)
 {
     (void)udata;
-    return malloc(size);
+    return oapv_malloc(size);
 }
 
 static void *oapv_ops_mem_calloc_libc(void *udata, unsigned int count, unsigned int size)
 {
     (void)udata;
-    return calloc(count, size);
+    return oapv_mcalloc(count, size);
 }
 
 static void *oapv_ops_mem_realloc_libc(void *udata, void *ptr, unsigned int size)
 {
     (void)udata;
-    return realloc(ptr, size);
+    return oapv_mrealloc(ptr, size);
 }
 
 static void oapv_ops_mem_free_libc(void *udata, void *ptr)
 {
     (void)udata;
-    free(ptr);
+    oapv_mfree(ptr);
 }
 
 void oapv_ops_mem_default(oapv_ops_mem_t *dst)
 {
     dst->magic   = OAPV_OPS_MAGIC_CODE_MEM;
-    dst->malloc  = oapv_ops_mem_malloc_libc;
+    dst->malloc  = oapv_ops_mem_alloc_libc;
     dst->calloc  = oapv_ops_mem_calloc_libc;
     dst->realloc = oapv_ops_mem_realloc_libc;
     dst->free    = oapv_ops_mem_free_libc;
     dst->udata   = NULL;
+}
+
+int oapv_ops_mem_set(oapv_ops_mem_t *dst, const oapv_ops_mem_t *src)
+{
+    int nset;
+    if(src == NULL) {
+        oapv_ops_mem_default(dst);
+        return OAPV_OK;
+    }
+    nset = (src->malloc != NULL) + (src->calloc != NULL) +
+           (src->realloc != NULL) + (src->free != NULL);
+    if(nset == 0) {
+        oapv_ops_mem_default(dst);
+        return OAPV_OK;
+    }
+    if(nset == 4 && src->magic == OAPV_OPS_MAGIC_CODE_MEM) {
+        *dst = *src;
+        return OAPV_OK;
+    }
+    return OAPV_ERR_INVALID_ARGUMENT;
 }
 
 void oapv_trace0(char *filename, int line, const char *fmt, ...)

--- a/src/oapv_port.h
+++ b/src/oapv_port.h
@@ -158,7 +158,6 @@ void oapv_trace_line(char *pre);
  * memory operations
  *****************************************************************************/
 #define oapv_malloc(size)         malloc((size))
-#define oapv_malloc_fast(size)    oapv_malloc((size))
 #define oapv_mcalloc(count, size) calloc((count), (size))
 #define oapv_mrealloc(ptr, size)  realloc((ptr), (size))
 
@@ -167,12 +166,6 @@ void oapv_trace_line(char *pre);
         if(m) {       \
             free(m);  \
         }             \
-    }
-#define oapv_mfree_fast(m) \
-    {                      \
-        if(m) {            \
-            oapv_mfree(m); \
-        }                  \
     }
 
 /* Fill 'dst' with the default standard-C-library allocator interface. */

--- a/src/oapv_port.h
+++ b/src/oapv_port.h
@@ -157,8 +157,10 @@ void oapv_trace_line(char *pre);
 /*****************************************************************************
  * memory operations
  *****************************************************************************/
-#define oapv_malloc(size)      malloc((size))
-#define oapv_malloc_fast(size) oapv_malloc((size))
+#define oapv_malloc(size)         malloc((size))
+#define oapv_malloc_fast(size)    oapv_malloc((size))
+#define oapv_mcalloc(count, size) calloc((count), (size))
+#define oapv_mrealloc(ptr, size)  realloc((ptr), (size))
 
 #define oapv_mfree(m) \
     {                 \
@@ -175,6 +177,16 @@ void oapv_trace_line(char *pre);
 
 /* Fill 'dst' with the default standard-C-library allocator interface. */
 void oapv_ops_mem_default(oapv_ops_mem_t *dst);
+
+/* Resolve caller-supplied 'src' into 'dst'. NULL or an all-NULL interface
+   selects the default; a partially-filled one is rejected. */
+int oapv_ops_mem_set(oapv_ops_mem_t *dst, const oapv_ops_mem_t *src);
+
+/* allocate/free through the instance's resolved memory interface */
+#define oapv_ops_malloc(ctx, size) \
+    ((ctx)->ops_mem.malloc((ctx)->ops_mem.udata, (size)))
+#define oapv_ops_free(ctx, ptr) \
+    ((ctx)->ops_mem.free((ctx)->ops_mem.udata, (ptr)))
 
 #define oapv_mcpy(dst, src, size)    memcpy((dst), (src), (size))
 #define oapv_mset(dst, v, size)      memset((dst), (v), (size))

--- a/src/oapv_port.h
+++ b/src/oapv_port.h
@@ -173,8 +173,8 @@ void oapv_trace_line(char *pre);
         }                  \
     }
 
-void *oapv_malloc_align32(int size);
-void oapv_mfree_align32(void *p);
+/* Fill 'dst' with the default standard-C-library allocator interface. */
+void oapv_ops_mem_default(oapv_ops_mem_t *dst);
 
 #define oapv_mcpy(dst, src, size)    memcpy((dst), (src), (size))
 #define oapv_mset(dst, v, size)      memset((dst), (v), (size))

--- a/src/oapv_tpool.c
+++ b/src/oapv_tpool.c
@@ -31,6 +31,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include "oapv_def.h"
 #include "oapv_tpool.h"
 #if defined(WIN32) || defined(WIN64)
 #include <windows.h>
@@ -58,10 +59,12 @@ typedef struct thread_ctx {
     tpool_result_t         t_result;
     int                    thread_id;
     int                    task_ret; // return value of task function
+    oapv_ops_mem_t         ops_mem;  // memory allocator of the owning pool
 } thread_ctx_t;
 
 typedef struct thread_mutex {
     pthread_mutex_t lmutex;
+    oapv_ops_mem_t  ops_mem;
 } thread_mutex_t;
 
 static void *tpool_worker_thread(void *arg)
@@ -122,11 +125,12 @@ static oapv_thread_t tpool_create_thread(oapv_tpool_t *tp, int thread_id)
 
     thread_ctx_t *tctx = NULL;
 
-    tctx = (thread_ctx_t *)malloc(sizeof(thread_ctx_t));
+    tctx = (thread_ctx_t *)oapv_ops_malloc(tp, sizeof(thread_ctx_t));
 
     if(!tctx) {
         return NULL; // error management, bad alloc
     }
+    tctx->ops_mem = tp->ops_mem;
 
     int result = 1;
 
@@ -182,7 +186,7 @@ ERR_WCOND:
 ERR_MUTEX:
     pthread_mutex_destroy(&tctx->c_section);
 ERR_FREE:
-    free(tctx);
+    oapv_ops_free(tp, tctx);
 
     return NULL; // can't create a worker thread with proper initialization
 }
@@ -272,7 +276,7 @@ static tpool_result_t tpool_terminate_thread(oapv_thread_t *thread_id)
     pthread_cond_destroy(&t_context->r_event);
 
     // delete the thread context memory
-    free(t_context);
+    oapv_ops_free(t_context, t_context);
     (*thread_id) = NULL;
     return TPOOL_SUCCESS;
 }
@@ -291,18 +295,19 @@ static int tpool_threadsafe_decrement(oapv_sync_obj_t sobj, volatile int *pcnt)
     return temp;
 }
 
-oapv_sync_obj_t oapv_tpool_sync_obj_create()
+oapv_sync_obj_t oapv_tpool_sync_obj_create(const oapv_ops_mem_t *ops)
 {
-    thread_mutex_t *imutex = (thread_mutex_t *)malloc(sizeof(thread_mutex_t));
+    thread_mutex_t *imutex = (thread_mutex_t *)ops->malloc(ops->udata, sizeof(thread_mutex_t));
     if(0 == imutex) {
         return 0; // failure case
     }
+    imutex->ops_mem = *ops;
 
     // intialize the mutex
     int result = pthread_mutex_init(&imutex->lmutex, NULL);
     if(result) {
         if(imutex) {
-            free(imutex);
+            ops->free(ops->udata, imutex);
         }
         imutex = 0;
     }
@@ -320,7 +325,7 @@ tpool_result_t oapv_tpool_sync_obj_delete(oapv_sync_obj_t *sobj)
     pthread_mutex_destroy(&imutex->lmutex);
 
     // free the memory
-    free(imutex);
+    oapv_ops_free(imutex, imutex);
     *sobj = NULL;
 
     return TPOOL_SUCCESS;
@@ -353,6 +358,7 @@ typedef struct thread_ctx {
     tpool_result_t         t_result;
     int                    task_ret;
     int                    thread_id;
+    oapv_ops_mem_t         ops_mem; // memory allocator of the owning pool
 
 } thread_ctx_t;
 
@@ -362,6 +368,7 @@ typedef struct thread_mutex {
 #else
     CRITICAL_SECTION c_section; // critical section for fast synchronization
 #endif
+    oapv_ops_mem_t ops_mem;
 
 } thread_mutex_t;
 
@@ -415,11 +422,12 @@ static oapv_thread_t tpool_create_thread(oapv_tpool_t *tp, int thread_id)
     }
 
     thread_ctx_t *thread_context = NULL;
-    thread_context = (thread_ctx_t *)malloc(sizeof(thread_ctx_t));
+    thread_context = (thread_ctx_t *)oapv_ops_malloc(tp, sizeof(thread_ctx_t));
 
     if(!thread_context) {
         return NULL; // error management, bad alloc
     }
+    thread_context->ops_mem = tp->ops_mem;
 
     // create waiting event
     // create waiting event as automatic reset, only one thread can come out of waiting state
@@ -461,7 +469,7 @@ TERROR:
     }
     DeleteCriticalSection(&thread_context->c_section);
     if(thread_context) {
-        free(thread_context);
+        oapv_ops_free(tp, thread_context);
     }
 
     return NULL; // error handling, can't create a worker thread with proper initialization
@@ -553,7 +561,7 @@ tpool_result_t tpool_terminate_thread(oapv_thread_t *thread_id)
     DeleteCriticalSection(&t_context->c_section);
 
     // delete the thread context memory
-    free(t_context);
+    oapv_ops_free(t_context, t_context);
     (*thread_id) = NULL;
 
     return TPOOL_SUCCESS;
@@ -593,19 +601,20 @@ static int tpool_threadsafe_decrement(oapv_sync_obj_t sobj, volatile int *pcnt)
     return temp;
 }
 
-oapv_sync_obj_t oapv_tpool_sync_obj_create()
+oapv_sync_obj_t oapv_tpool_sync_obj_create(const oapv_ops_mem_t *ops)
 {
-    thread_mutex_t *imutex = (thread_mutex_t *)malloc(sizeof(thread_mutex_t));
+    thread_mutex_t *imutex = (thread_mutex_t *)ops->malloc(ops->udata, sizeof(thread_mutex_t));
     if(0 == imutex) {
         return 0; // failure case
     }
+    imutex->ops_mem = *ops;
 
 #if WINDOWS_MUTEX_SYNC
     // initialize the created mutex instance
     imutex->lmutex = CreateMutex(NULL, FALSE, NULL);
     if(0 == imutex->lmutex) {
         if(imutex) {
-            free(imutex);
+            ops->free(ops->udata, imutex);
         }
         return 0;
     }
@@ -630,7 +639,7 @@ tpool_result_t oapv_tpool_sync_obj_delete(oapv_sync_obj_t *sobj)
 #endif
 
     // free the memory
-    free(imutex);
+    oapv_ops_free(imutex, imutex);
     *sobj = NULL;
 
     return TPOOL_SUCCESS;
@@ -649,12 +658,13 @@ void oapv_tpool_leave_cs(oapv_sync_obj_t sobj)
 
 #endif
 
-tpool_result_t oapv_tpool_init(oapv_tpool_t *tp, int maxtask)
+tpool_result_t oapv_tpool_init(oapv_tpool_t *tp, const oapv_ops_mem_t *ops, int maxtask)
 {
-    if(tp == NULL) return TPOOL_INVALID_ARG;
+    if(tp == NULL || ops == NULL) return TPOOL_INVALID_ARG;
     // assign handles to threadcontroller object
     // handles for create, run, join and terminate will be given to controller  object
 
+    tp->ops_mem = *ops;
     tp->create = tpool_create_thread;
     tp->run = tpool_assign_task;
     tp->join = tpool_retrieve_result;

--- a/src/oapv_tpool.h
+++ b/src/oapv_tpool.h
@@ -69,12 +69,14 @@ struct oapv_tpool {
     tpool_result_t (*release)(oapv_thread_t *thread_id);
     // handle for mask number of allowed thread
     int max_task_cnt;
+    // memory allocator of the owning codec instance
+    oapv_ops_mem_t ops_mem;
 };
 
-tpool_result_t oapv_tpool_init(oapv_tpool_t *tp, int maxtask);
+tpool_result_t oapv_tpool_init(oapv_tpool_t *tp, const oapv_ops_mem_t *ops, int maxtask);
 tpool_result_t oapv_tpool_deinit(oapv_tpool_t *tp);
 
-oapv_sync_obj_t oapv_tpool_sync_obj_create();
+oapv_sync_obj_t oapv_tpool_sync_obj_create(const oapv_ops_mem_t *ops);
 tpool_result_t oapv_tpool_sync_obj_delete(oapv_sync_obj_t *sobj);
 int oapv_tpool_spinlock_wait(volatile int *addr, int val);
 

--- a/src/oapv_util.c
+++ b/src/oapv_util.c
@@ -313,15 +313,17 @@ int oapv_set_md5_pld(oapvm_t mid, int group_id, oapv_imgb_t *rec)
 {
     int ret = oapv_imgb_set_md5(rec);
     oapv_assert_rv(OAPV_SUCCEEDED(ret), ret);
-    u8 *mdp_data = oapv_malloc((16 * rec->np) + 16);
+    oapvm_ctx_t *mctx = oapvm_id_to_ctx(mid);
+    oapv_assert_rv(mctx != NULL, OAPV_ERR_INVALID_ARGUMENT);
+    u8 *mdp_data = oapv_ops_malloc(mctx, (16 * rec->np) + 16);
     oapv_assert_rv(mdp_data != NULL, OAPV_ERR_OUT_OF_MEMORY);
     memcpy(mdp_data, uuid_frm_hash, 16);
     for(int i = 0; i < rec->np; i++) {
         memcpy(mdp_data + ((i + 1) * 16), rec->hash[i], 16);
     }
     ret = oapvm_set(mid, group_id, OAPV_METADATA_USER_DEFINED, mdp_data, 16 * rec->np + 16);
+    oapv_ops_free(mctx, mdp_data);
     oapv_assert_rv(OAPV_SUCCEEDED(ret), ret);
-    oapv_mfree(mdp_data);
     return OAPV_OK;
 }
 


### PR DESCRIPTION
This adds a way for applications to supply their own memory allocator, as discussed in #228.

- New `oapv_ops_mem_t` interface (`malloc`/`calloc`/`realloc`/`free` plus an opaque `udata`), passed through the creation descriptors: `oapve_cdesc_t`, `oapvd_cdesc_t`, and a new `oapvm_cdesc_t` for the metadata container
- All internal allocations are routed through the instance allocator — encoder, decoder, metadata container, and thread pool. No raw `malloc`/`free` calls remain in the library
- Leaving `ops_mem` as `NULL` keeps the standard C library behavior; there is no global allocator state
- Note: `oapvm_create()` now takes a descriptor argument, so metadata container callers need a small update

Usage is documented in the "Custom memory allocator" section of the README.

