### PR TITLE
Write tile sizes into the frame header by default

### DIFF
--- a/app/oapv_app_enc.c
+++ b/app/oapv_app_enc.c
@@ -277,6 +277,10 @@ static const args_opt_t enc_args_opts[] = {
         "embed frame hash value for conformance checking in decoding"
     },
     {
+        ARGS_NO_KEY,  "disable-tile-size-in-fh", ARGS_VAL_TYPE_NONE, 0, NULL, 0,
+        "do not write tile size values into the frame header"
+    },
+    {
         ARGS_NO_KEY,  "master-display", ARGS_VAL_TYPE_STRING, 0, NULL, 0,
         "mastering display color volume metadata"
     },
@@ -298,6 +302,7 @@ typedef struct args_var {
     char           fname_rec[256];
     int            max_au;
     int            hash;
+    int            disable_tile_size_in_fh;
     int            input_depth;
     int            input_csp;
     int            seek;
@@ -356,6 +361,7 @@ static args_var_t *args_init_vars(args_parser_t *args, oapve_param_t *param)
     args_set_variable_by_key_long(opts, "recon", vars->fname_rec, sizeof(vars->fname_rec));
     args_set_variable_by_key_long(opts, "max-au", &vars->max_au, 0);
     args_set_variable_by_key_long(opts, "hash", &vars->hash, 0);
+    args_set_variable_by_key_long(opts, "disable-tile-size-in-fh", &vars->disable_tile_size_in_fh, 0);
     args_set_variable_by_key_long(opts, "verbose", &op_verbose, 0);
     op_verbose = VERBOSE_SIMPLE; /* default */
     args_set_variable_by_key_long(opts, "input-depth", &vars->input_depth, 0);
@@ -520,9 +526,18 @@ static int set_extra_config(oapve_t id, args_var_t *vars, oapve_param_t *param)
     if(vars->hash) {
         value = 1;
         size = 4;
-        ret = oapve_config(id, OAPV_CFG_FRM(OAPV_CFG_SET_USE_FRM_HASH, 0), &value, &size);
+        ret = oapve_config(id, OAPV_CFG_FRM(OAPV_CFG_SET_USE_FRM_HASH, FRM_IDX), &value, &size);
         if(OAPV_FAILED(ret)) {
             logerr("ERR: failed to set config for using frame hash\n");
+            return -1;
+        }
+    }
+    if(vars->disable_tile_size_in_fh) {
+        value = 0;
+        size = 4;
+        ret = oapve_config(id, OAPV_CFG_FRM(OAPV_CFG_SET_TILE_SIZE_IN_FH, FRM_IDX), &value, &size);
+        if(OAPV_FAILED(ret)) {
+            logerr("ERR: failed to set config for tile size in frame header\n");
             return -1;
         }
     }

--- a/inc/oapv.h
+++ b/inc/oapv.h
@@ -183,6 +183,7 @@ extern "C" {
 #define OAPV_CFG_SET_QP_MAX             (209)
 #define OAPV_CFG_SET_USE_FRM_HASH       (301)
 #define OAPV_CFG_SET_AU_BS_FMT          (302)
+#define OAPV_CFG_SET_TILE_SIZE_IN_FH    (303)
 #define OAPV_CFG_SET_DISABLE_COMPANDING (400)
 #define OAPV_CFG_GET_QP_MIN             (600)
 #define OAPV_CFG_GET_QP_MAX             (601)
@@ -194,6 +195,7 @@ extern "C" {
 #define OAPV_CFG_GET_WIDTH              (701)
 #define OAPV_CFG_GET_HEIGHT             (702)
 #define OAPV_CFG_GET_AU_BS_FMT          (802)
+#define OAPV_CFG_GET_TILE_SIZE_IN_FH    (803)
 
 /* Target a specific frame's parameters in oapve_config(): the upper 16 bits of
  * 'cfg' carry the frame index, the lower 16 bits the config id above. Legacy

--- a/src/oapv.c
+++ b/src/oapv.c
@@ -611,6 +611,9 @@ static int enc_ready(oapve_ctx_t *ctx)
         ctx->rc_param_frm[i].beta = OAPV_RC_BETA;
     }
     ctx->au_bs_fmt = OAPV_CFG_VAL_AU_BS_FMT_RBAU; // default: enable raw bitstream format
+    for(int i = 0; i < OAPV_MAX_NUM_FRAMES; i++) {
+        ctx->tile_size_in_fh[i] = 1; // default: write tile sizes in frame header
+    }
 
     return OAPV_OK;
 ERR:
@@ -1242,8 +1245,9 @@ int oapve_encode(oapve_t eid, oapv_frms_t *ifrms, oapvm_t mid, oapv_bitb_t *bitb
 
         /* Load this frame slot's RC state into the working ctx->rc_param so
          * enc_frame and oapve_rc_update_after_pic operate on per-slot alpha/beta. */
-        int rc_slot = oapv_min(i, OAPV_MAX_NUM_FRAMES - 1);
-        ctx->rc_param = ctx->rc_param_frm[rc_slot];
+        // 'i' is bounded by the num_frms check at the top of this function
+        ctx->rc_param = ctx->rc_param_frm[i];
+        ctx->frm_idx = i;
 
         // write headers
         bs_pos_pbu_beg = oapv_bsw_sink(bs);            /* store pbu pos to calculate size */
@@ -1255,7 +1259,7 @@ int oapve_encode(oapve_t eid, oapv_frms_t *ifrms, oapvm_t mid, oapv_bitb_t *bitb
         oapv_assert_rv(OAPV_SUCCEEDED(ret), ret);
 
         /* Save the updated RC state back into this slot for the next AU. */
-        ctx->rc_param_frm[rc_slot] = ctx->rc_param;
+        ctx->rc_param_frm[i] = ctx->rc_param;
 
         // rewrite pbu_size
         int pbu_size = ((u8 *)oapv_bsw_sink(bs)) - bs_pos_pbu_beg - 4;
@@ -1372,6 +1376,10 @@ int oapve_config(oapve_t eid, int cfg, void *buf, int *size)
         oapv_assert_rv(t0 == OAPV_CFG_VAL_AU_BS_FMT_RBAU || t0 == OAPV_CFG_VAL_AU_BS_FMT_NONE, OAPV_ERR_INVALID_ARGUMENT);
         ctx->au_bs_fmt = t0;
         break;
+    case OAPV_CFG_SET_TILE_SIZE_IN_FH:
+        oapv_assert_rv(*size == sizeof(int), OAPV_ERR_INVALID_ARGUMENT);
+        ctx->tile_size_in_fh[frm_idx] = (*((int *)buf)) ? 1 : 0;
+        break;
     /* get config *******************************************************/
     case OAPV_CFG_GET_QP:
         oapv_assert_rv(*size == sizeof(int), OAPV_ERR_INVALID_ARGUMENT);
@@ -1400,6 +1408,10 @@ int oapve_config(oapve_t eid, int cfg, void *buf, int *size)
     case OAPV_CFG_GET_AU_BS_FMT:
         oapv_assert_rv(*size == sizeof(int), OAPV_ERR_INVALID_ARGUMENT);
         *((int *)buf) = ctx->au_bs_fmt;
+        break;
+    case OAPV_CFG_GET_TILE_SIZE_IN_FH:
+        oapv_assert_rv(*size == sizeof(int), OAPV_ERR_INVALID_ARGUMENT);
+        *((int *)buf) = ctx->tile_size_in_fh[frm_idx];
         break;
     default:
         oapv_trace("unknown config value (%d)\n", cfg);

--- a/src/oapv.c
+++ b/src/oapv.c
@@ -1273,7 +1273,7 @@ int oapve_encode(oapve_t eid, oapv_frms_t *ifrms, oapvm_t mid, oapv_bitb_t *bitb
         fh_to_finfo(&ctx->fh, frm->pbu_type, frm->group_id, &stat->aui.frm_info[i]);
 
         // add frame hash value of reconstructed frame into metadata list
-        if(ctx->use_frm_hash) {
+        if(ctx->use_frm_hash[i]) {
             if(frm->pbu_type == OAPV_PBU_TYPE_PRIMARY_FRAME ||
                frm->pbu_type == OAPV_PBU_TYPE_NON_PRIMARY_FRAME) {
                 oapv_assert_rv(mid != NULL, OAPV_ERR_INVALID_ARGUMENT);
@@ -1368,7 +1368,7 @@ int oapve_config(oapve_t eid, int cfg, void *buf, int *size)
         break;
     case OAPV_CFG_SET_USE_FRM_HASH:
         oapv_assert_rv(*size == sizeof(int), OAPV_ERR_INVALID_ARGUMENT);
-        ctx->use_frm_hash = (*((int *)buf)) ? 1 : 0;
+        ctx->use_frm_hash[frm_idx] = (*((int *)buf)) ? 1 : 0;
         break;
     case OAPV_CFG_SET_AU_BS_FMT:
         oapv_assert_rv(*size == sizeof(int), OAPV_ERR_INVALID_ARGUMENT);

--- a/src/oapv_def.h
+++ b/src/oapv_def.h
@@ -305,7 +305,7 @@ struct oapve_ctx {
     int                        bit_depth;     // bit-depth of internal part
     int                        bit_depth_inp; // bit-depth of input video
     int                        c_sft[N_C][2]; // width or height shift value of each compoents, 0: width, 1: height
-    int                        use_frm_hash;
+    int                        use_frm_hash[OAPV_MAX_NUM_FRAMES]; // embed frame hash metadata, per frame
     int                        use_companding;
 
     const oapv_fn_itx_part_t  *fn_itx_part;

--- a/src/oapv_def.h
+++ b/src/oapv_def.h
@@ -290,6 +290,8 @@ struct oapve_ctx {
     oapv_sync_obj_t            sync_obj;
     int                        threads; // num of thread for encoding
     int                        au_bs_fmt; // access unit bitstream format
+    int                        tile_size_in_fh[OAPV_MAX_NUM_FRAMES]; // write tile sizes in frame header, per frame
+    int                        frm_idx; // index of the frame being encoded in the current access unit
     int                        num_tiles_frms[OAPV_MAX_NUM_FRAMES];
     int                        num_tiles;
     int                        num_tile_cols;

--- a/src/oapv_vlc.c
+++ b/src/oapv_vlc.c
@@ -320,7 +320,7 @@ void oapve_set_frame_header(oapve_ctx_t *ctx, oapv_fh_t *fh)
             }
         }
     }
-    fh->tile_size_present_in_fh_flag = 0;
+    fh->tile_size_present_in_fh_flag = ctx->tile_size_in_fh[ctx->frm_idx] ? 1 : 0;
 }
 
 void oapve_set_tile_header(oapve_ctx_t *ctx, oapv_th_t *th, int tile_idx, int qp)


### PR DESCRIPTION
This enables the `tile_size_present_in_fh_flag` path discussed in #228, so a
decoder can index individual tiles from the frame header without scanning the
tile data.

- The encoder now writes `tile_size_in_fh[]` (u(32) per tile) by default,
  reusing the existing frame header rewrite after tile encoding, in the same
  way `pbu_size` is backfilled
- `oapve_config()` gets `OAPV_CFG_SET/GET_TILE_SIZE_IN_FH`, settable per
  frame through `OAPV_CFG_FRM()`; the encoder app disables it with
  `--disable-tile-size-in-fh`
- The per-frame RC slot indexing in `oapve_encode()` now uses the loop index
  directly instead of a clamped copy, since the frame count is already
  validated at the function entry
