### PR TITLE
Store the frame hash config per frame

### DIFF
--- a/src/oapv.c
+++ b/src/oapv.c
@@ -1269,7 +1269,7 @@ int oapve_encode(oapve_t eid, oapv_frms_t *ifrms, oapvm_t mid, oapv_bitb_t *bitb
         fh_to_finfo(&ctx->fh, frm->pbu_type, frm->group_id, &stat->aui.frm_info[i]);
 
         // add frame hash value of reconstructed frame into metadata list
-        if(ctx->use_frm_hash) {
+        if(ctx->use_frm_hash[i]) {
             if(frm->pbu_type == OAPV_PBU_TYPE_PRIMARY_FRAME ||
                frm->pbu_type == OAPV_PBU_TYPE_NON_PRIMARY_FRAME) {
                 oapv_assert_rv(mid != NULL, OAPV_ERR_INVALID_ARGUMENT);
@@ -1364,7 +1364,7 @@ int oapve_config(oapve_t eid, int cfg, void *buf, int *size)
         break;
     case OAPV_CFG_SET_USE_FRM_HASH:
         oapv_assert_rv(*size == sizeof(int), OAPV_ERR_INVALID_ARGUMENT);
-        ctx->use_frm_hash = (*((int *)buf)) ? 1 : 0;
+        ctx->use_frm_hash[frm_idx] = (*((int *)buf)) ? 1 : 0;
         break;
     case OAPV_CFG_SET_AU_BS_FMT:
         oapv_assert_rv(*size == sizeof(int), OAPV_ERR_INVALID_ARGUMENT);

--- a/src/oapv_def.h
+++ b/src/oapv_def.h
@@ -303,7 +303,7 @@ struct oapve_ctx {
     int                        bit_depth;     // bit-depth of internal part
     int                        bit_depth_inp; // bit-depth of input video
     int                        c_sft[N_C][2]; // width or height shift value of each compoents, 0: width, 1: height
-    int                        use_frm_hash;
+    int                        use_frm_hash[OAPV_MAX_NUM_FRAMES]; // embed frame hash metadata, per frame
     int                        use_companding;
 
     const oapv_fn_itx_part_t  *fn_itx_part;


### PR DESCRIPTION
`OAPV_CFG_SET_USE_FRM_HASH` is called with a frame index through
`OAPV_CFG_FRM()`, but the value was stored in a single instance-wide field,
so the index was silently ignored and the setting applied to every frame of
an access unit.

The encoder now keeps the setting per frame and reads the current frame's
value in the encoding loop, so `OAPV_CFG_FRM(OAPV_CFG_SET_USE_FRM_HASH, n)`
behaves as the call form suggests. The decoder-side flag is a plain
verification toggle and is unchanged.
