### PR TITLE
Install libraries in prefix/lib as declared by pkg-config

### DIFF
--- a/pkgconfig/oapv.pc.in
+++ b/pkgconfig/oapv.pc.in
@@ -11,7 +11,7 @@ Version: @VERSION_APISET@.@VERSION_MAJOR@.@VERSION_MINOR@.@VERSION_PATCH@
 
 Requires:
 Libs: -L${libdir} -l@LIB_NAME_BASE@
-Libs.private: -L${libdir}/@LIB_NAME_BASE@ -lm
+Libs.private: -lm
 
 Cflags: -I${includedir} @EXTRA_CFLAGS@
 Cflags.private: @EXTRA_CFLAGS_PRIVATE@

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -108,7 +108,7 @@ if(MSVC)
 elseif(UNIX OR MINGW)
   if (ARM)
     set_property(SOURCE ${NEON} APPEND PROPERTY COMPILE_FLAGS "-flax-vector-conversions")
-elseif (X86 OR UNIVERSAL)
+  elseif (X86 OR UNIVERSAL)
     set_property(SOURCE ${SSE} APPEND PROPERTY COMPILE_FLAGS "-msse4.1")
     set_property(SOURCE ${AVX} APPEND PROPERTY COMPILE_FLAGS " -mavx2")
   endif()
@@ -142,20 +142,20 @@ set(OAPV_PRIVATE_HEADERS "${LIB_BASE_INC}" "${LIB_SSE_INC}" "${LIB_AVX_INC}" "${
 
 # Install static library and public headers
 #
-# Static library (liboapv.a or oapv.lib) will be installed to <prefix>/lib/oapv
+# Static library (liboapv.a or oapv.lib) will be installed to <prefix>/lib
 # Public headers will be installed to <prefix>/include/oapv
 #
 if(OAPV_BUILD_STATIC_LIB)
   set_target_properties(${LIB_NAME_BASE} PROPERTIES PUBLIC_HEADER "${OAPV_PUBLIC_HEADERS}")
   install(TARGETS ${LIB_NAME_BASE}
-          ARCHIVE COMPONENT Development DESTINATION ${CMAKE_INSTALL_LIBDIR}/${LIB_NAME_BASE}
+          ARCHIVE COMPONENT Development DESTINATION ${CMAKE_INSTALL_LIBDIR}
           PUBLIC_HEADER COMPONENT Development DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${LIB_NAME_BASE}
   )
 endif()
 
 # Install shared library
 #
-# On non-DLL platforms shared library (liboapv.so) will be installed to <prefix>/lib/oapv.
+# On non-DLL platforms shared library (liboapv.so) will be installed to <prefix>/lib.
 # On DLL platforms the shred DLL (oapv.dll) will be installed to <prefix>/bin and its import library will be installed to <prefix>/lib/oapv/import
 #
 if(OAPV_BUILD_SHARED_LIB)
@@ -165,7 +165,7 @@ if(OAPV_BUILD_SHARED_LIB)
           LIBRARY
             COMPONENT Libraries DESTINATION ${CMAKE_INSTALL_LIBDIR}
             NAMELINK_COMPONENT Development DESTINATION ${CMAKE_INSTALL_LIBDIR}
-          ARCHIVE COMPONENT Development DESTINATION ${CMAKE_INSTALL_LIBDIR}/${LIB_NAME_BASE}/import
+          ARCHIVE COMPONENT Development DESTINATION ${CMAKE_INSTALL_LIBDIR}/import
           PUBLIC_HEADER COMPONENT Development DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${LIB_NAME_BASE}
   )
 


### PR DESCRIPTION
This supersedes #166 by @robUx4, with the original commit cherry-picked and authorship preserved.

The static library was installed to `<prefix>/lib/oapv/` while the generated `.pc` file declares `libdir=<prefix>/lib` and `Libs: -L${libdir} -loapv`, so consumers resolving the library through pkg-config (e.g. ffmpeg's configure) could not link against a static-only installation. Libraries now install to `<prefix>/lib` as the `.pc` file states, and the DLL import library moves to `<prefix>/lib/import`.

The follow-up commit drops the now stale `-L${libdir}/oapv` path from `Libs.private`.

Verified with a staged install: a test program links via `pkg-config --cflags/--libs` against a shared installation, and via `--libs --static` against a static-only installation (the latter fails on current main).

Note for packagers: the shared library location is unchanged, so already built applications are unaffected. Reinstalling over an existing prefix leaves the old `<prefix>/lib/oapv/liboapv.a` behind, and build scripts that hardcoded `-L<prefix>/lib/oapv` to work around the mismatch would silently pick up that stale copy — remove the old directory or use the pkg-config paths.
