### PR TITLE
Fix pkg-config include paths for non-default install prefixes

### DIFF
--- a/pkgconfig/oapv.pc.in
+++ b/pkgconfig/oapv.pc.in
@@ -1,8 +1,8 @@
 # --- oapv.pc.in file ---
-prefix=@CMAKE_INSTALL_PREFIX@ 
-exec_prefix=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_BINDIR@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
 libdir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@
-includedir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@/@LIB_NAME_BASE@
+includedir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: oapv
 Description: Advanced Professional Video Codec
@@ -13,5 +13,5 @@ Requires:
 Libs: -L${libdir} -l@LIB_NAME_BASE@
 Libs.private: -lm
 
-Cflags: -I${includedir} @EXTRA_CFLAGS@
+Cflags: -I${includedir} -I${includedir}/@LIB_NAME_BASE@ @EXTRA_CFLAGS@
 Cflags.private: @EXTRA_CFLAGS_PRIVATE@


### PR DESCRIPTION
The `.pc` file pointed `includedir` at `<prefix>/include/oapv`, so `#include <oapv/oapv.h>` (the style ffmpeg uses) and the `<oapv/oapv_exports.h>` include inside `oapv.h` only resolved when the install prefix happened to be a default compiler search path such as `/usr/local`. With a custom prefix, compiling any consumer against the installed headers failed.

`includedir` now points at `<prefix>/include` and `Cflags` provides both `-I${includedir}` and `-I${includedir}/oapv`, so both `#include <oapv/oapv.h>` and `#include <oapv.h>` work regardless of prefix. Also sets `exec_prefix` to `${prefix}` per convention and drops a stray trailing space.

Verified with a staged install to a non-default prefix: both include styles compile and link against a shared installation, and a static-only installation links via `pkg-config --libs --static`.
