### PR TITLE
Make tile scheduling linear instead of quadratic

### DIFF
--- a/src/oapv.c
+++ b/src/oapv.c
@@ -789,6 +789,7 @@ static int enc_thread_tile(void *arg)
         oapv_tpool_enter_cs(ctx->sync_obj);
         core->tile_idx = ctx->tile_idx;
         if (ctx->tile_idx < ctx->num_tiles) {
+            oapv_assert(tile[core->tile_idx].stat == ENC_TILE_STAT_NOT_ENCODED);
             tile[core->tile_idx].stat = ENC_TILE_STAT_ON_ENCODING;
             ++ctx->tile_idx;
         }
@@ -800,7 +801,9 @@ static int enc_thread_tile(void *arg)
         ret = enc_tile(ctx, core, &tile[core->tile_idx]);
         oapv_assert_g(OAPV_SUCCEEDED(ret), ERR);
 
+        oapv_tpool_enter_cs(ctx->sync_obj);
         tile[core->tile_idx].stat = ENC_TILE_STAT_ENCODED;
+        oapv_tpool_leave_cs(ctx->sync_obj);
     }
 ERR:
     return ret;
@@ -1761,6 +1764,7 @@ static int dec_thread_tile(void *arg)
         oapv_tpool_enter_cs(ctx->sync_obj);
         tidx = ctx->tile_idx;
         if (ctx->tile_idx < ctx->num_tiles) {
+            oapv_assert(DEC_TILE_STAT_IS_DO(tile[tidx].stat));
             tile[tidx].stat = DEC_TILE_STAT_ON(tile[tidx].stat);
             ++ctx->tile_idx;
         }
@@ -1800,6 +1804,7 @@ static int dec_thread_tile(void *arg)
             ret = dec_tile(core, &tile[tidx]);
         }
 
+        oapv_tpool_enter_cs(ctx->sync_obj);
         if (OAPV_SUCCEEDED(ret)) {
             tile[tidx].stat = DEC_TILE_STAT_DONE(tile[tidx].stat);
         }
@@ -1807,6 +1812,7 @@ static int dec_thread_tile(void *arg)
             tile[tidx].stat = DEC_TILE_STAT_ERR(tile[tidx].stat);
             thread_ret = ret;
         }
+        oapv_tpool_leave_cs(ctx->sync_obj);
     }
     return thread_ret;
 

--- a/src/oapv.c
+++ b/src/oapv.c
@@ -782,29 +782,25 @@ static int enc_thread_tile(void *arg)
     oapve_core_t *core = (oapve_core_t *)arg;
     oapve_ctx_t  *ctx = core->ctx;
     oapve_tile_t *tile = ctx->tile;
-    int           ret = OAPV_OK, i;
+    int           ret = OAPV_OK;
 
     while(1) {
         // find not encoded tile
         oapv_tpool_enter_cs(ctx->sync_obj);
-        for(i = 0; i < ctx->num_tiles; i++) {
-            if(tile[i].stat == ENC_TILE_STAT_NOT_ENCODED) {
-                tile[i].stat = ENC_TILE_STAT_ON_ENCODING;
-                core->tile_idx = i;
-                break;
-            }
+        core->tile_idx = ctx->tile_idx;
+        if (ctx->tile_idx < ctx->num_tiles) {
+            tile[core->tile_idx].stat = ENC_TILE_STAT_ON_ENCODING;
+            ++ctx->tile_idx;
         }
         oapv_tpool_leave_cs(ctx->sync_obj);
-        if(i == ctx->num_tiles) {
+        if(core->tile_idx == ctx->num_tiles) {
             break;
         }
 
         ret = enc_tile(ctx, core, &tile[core->tile_idx]);
         oapv_assert_g(OAPV_SUCCEEDED(ret), ERR);
 
-        oapv_tpool_enter_cs(ctx->sync_obj);
         tile[core->tile_idx].stat = ENC_TILE_STAT_ENCODED;
-        oapv_tpool_leave_cs(ctx->sync_obj);
     }
 ERR:
     return ret;
@@ -1069,6 +1065,7 @@ static int enc_frame(oapve_ctx_t *ctx, oapv_bs_t *bs)
     int           parallel_task = (ctx->threads > ctx->num_tiles) ? ctx->num_tiles : ctx->threads;
 
     /* encode tiles ************************************/
+    ctx->tile_idx = 0;
     for(tidx = 0; tidx < (parallel_task - 1); tidx++) {
         tpool->run(ctx->thread_id[tidx], enc_thread_tile,
                    (void *)ctx->core[tidx]);
@@ -1753,7 +1750,7 @@ static int dec_tile(oapvd_core_t *core, oapvd_tile_t *tile)
 static int dec_thread_tile(void *arg)
 {
     oapv_bs_t     bs;
-    int           i, ret, run, tidx = 0, thread_ret = OAPV_OK;
+    int           ret, run, tidx = 0, thread_ret = OAPV_OK;
 
     oapvd_core_t *core = (oapvd_core_t *)arg;
     oapvd_ctx_t  *ctx = core->ctx;
@@ -1762,15 +1759,13 @@ static int dec_thread_tile(void *arg)
     while(1) {
         // find not decoded tile
         oapv_tpool_enter_cs(ctx->sync_obj);
-        for(i = 0; i < ctx->num_tiles; i++) {
-            if(DEC_TILE_STAT_IS_DO(tile[i].stat)) {
-                tile[i].stat = DEC_TILE_STAT_ON(tile[i].stat);
-                tidx = i;
-                break;
-            }
+        tidx = ctx->tile_idx;
+        if (ctx->tile_idx < ctx->num_tiles) {
+            tile[tidx].stat = DEC_TILE_STAT_ON(tile[tidx].stat);
+            ++ctx->tile_idx;
         }
         oapv_tpool_leave_cs(ctx->sync_obj);
-        if(i == ctx->num_tiles) {
+        if(tidx == ctx->num_tiles) {
             break; // end of worker thread
         }
 
@@ -1801,11 +1796,10 @@ static int dec_thread_tile(void *arg)
         }
         oapv_tpool_leave_cs(ctx->sync_obj);
 
-        if(DEC_TILE_STAT_IS_DECODE(tile[i].stat)) {
+        if(DEC_TILE_STAT_IS_DECODE(tile[tidx].stat)) {
             ret = dec_tile(core, &tile[tidx]);
         }
 
-        oapv_tpool_enter_cs(ctx->sync_obj);
         if (OAPV_SUCCEEDED(ret)) {
             tile[tidx].stat = DEC_TILE_STAT_DONE(tile[tidx].stat);
         }
@@ -1813,7 +1807,6 @@ static int dec_thread_tile(void *arg)
             tile[tidx].stat = DEC_TILE_STAT_ERR(tile[tidx].stat);
             thread_ret = ret;
         }
-        oapv_tpool_leave_cs(ctx->sync_obj);
     }
     return thread_ret;
 
@@ -2062,6 +2055,7 @@ int oapvd_decode(oapvd_t did, oapv_bitb_t *bitb, oapv_frms_t *ofrms, oapvm_t mid
             parallel_task = (ctx->threads > ctx->num_tiles) ? ctx->num_tiles : ctx->threads;
 
             /* decode tiles ************************************/
+            ctx->tile_idx = 0;
             for(tidx = 0; tidx < (parallel_task - 1); tidx++) {
                 tpool->run(ctx->thread_id[tidx], dec_thread_tile,
                            (void *)ctx->core[tidx]);

--- a/src/oapv_def.h
+++ b/src/oapv_def.h
@@ -292,6 +292,7 @@ struct oapve_ctx {
     int                        frm_idx; // index of the frame being encoded in the current access unit
     int                        num_tiles_frms[OAPV_MAX_NUM_FRAMES];
     int                        num_tiles;
+    int                        tile_idx;
     int                        num_tile_cols;
     int                        num_tile_rows;
     int                        qp[N_C];
@@ -405,6 +406,7 @@ struct oapvd_ctx {
     oapv_sync_obj_t         sync_obj;
     u8                     *tile_end;
     int                     num_tiles;
+    int                     tile_idx;
     int                     num_tile_cols;
     int                     num_tile_rows;
     int                     w;

--- a/src/oapv_rc.c
+++ b/src/oapv_rc.c
@@ -84,6 +84,7 @@ int get_tile_cost_thread(void* arg)
         oapv_tpool_enter_cs(ctx->sync_obj);
         tidx = ctx->tile_idx;
         if (ctx->tile_idx < ctx->num_tiles) {
+            oapv_assert(tile[tidx].stat == ENC_TILE_STAT_NOT_ENCODED);
             tile[tidx].stat = ENC_TILE_STAT_ON_ENCODING;
             ++ctx->tile_idx;
         }
@@ -95,7 +96,9 @@ int get_tile_cost_thread(void* arg)
         ret = oapve_rc_get_tile_cost(ctx, core, &tile[tidx]);
         oapv_assert_g(OAPV_SUCCEEDED(ret), ERR);
 
+        oapv_tpool_enter_cs(ctx->sync_obj);
         tile[tidx].stat = ENC_TILE_STAT_ENCODED;
+        oapv_tpool_leave_cs(ctx->sync_obj);
     }
 ERR:
     return ret;

--- a/src/oapv_rc.c
+++ b/src/oapv_rc.c
@@ -77,29 +77,25 @@ int get_tile_cost_thread(void* arg)
     oapve_core_t* core = (oapve_core_t*)arg;
     oapve_ctx_t* ctx = core->ctx;
     oapve_tile_t* tile = ctx->tile;
-    int tidx = 0, ret = OAPV_OK, i;
+    int tidx = 0, ret = OAPV_OK;
 
     while (1) {
         // find not processed tile
         oapv_tpool_enter_cs(ctx->sync_obj);
-        for (i = 0; i < ctx->num_tiles; i++) {
-            if (tile[i].stat == ENC_TILE_STAT_NOT_ENCODED) {
-                tile[i].stat = ENC_TILE_STAT_ON_ENCODING;
-                tidx = i;
-                break;
-            }
+        tidx = ctx->tile_idx;
+        if (ctx->tile_idx < ctx->num_tiles) {
+            tile[tidx].stat = ENC_TILE_STAT_ON_ENCODING;
+            ++ctx->tile_idx;
         }
         oapv_tpool_leave_cs(ctx->sync_obj);
-        if (i == ctx->num_tiles) {
+        if (tidx == ctx->num_tiles) {
             break;
         }
 
         ret = oapve_rc_get_tile_cost(ctx, core, &tile[tidx]);
         oapv_assert_g(OAPV_SUCCEEDED(ret), ERR);
 
-        oapv_tpool_enter_cs(ctx->sync_obj);
         tile[tidx].stat = ENC_TILE_STAT_ENCODED;
-        oapv_tpool_leave_cs(ctx->sync_obj);
     }
 ERR:
     return ret;
@@ -115,6 +111,7 @@ int oapve_rc_get_tile_cost_thread(oapve_ctx_t* ctx, u64* sum)
     int parallel_task = (ctx->threads > ctx->num_tiles) ? ctx->num_tiles : ctx->threads;
 
     // run new threads
+    ctx->tile_idx = 0;
     int tidx = 0;
     for (tidx = 0; tidx < (parallel_task - 1); tidx++) {
         tpool->run(ctx->thread_id[tidx], get_tile_cost_thread, (void*)ctx->core[tidx]);


### PR DESCRIPTION
This adopts the tile scheduling change from #225 by @lordnn, with the original commit cherry-picked and authorship preserved.

Worker threads used to scan the tile status array from index 0 inside the critical section to find the next tile, making tile acquisition O(n) and a whole frame O(n^2). The scan is replaced with a shared next-tile counter, so acquisition is O(1). Since every tile is claimed exactly once in index order and the status array is initialized identically for full and partial decoding (every tile carries the DO flag, with DECODE or SKIP deciding the actual work), the processing semantics are unchanged.

Compared to #225 this adoption is conservative: `volatile` on the tile status stays, the completion status updates stay inside the critical section, and the claim invariants are asserted.

Verified against unpatched builds with identical outputs in all cases: the full test suite in Release and Debug, multithreaded encode bitstreams (plain and ABR rate control), full and cyclic tile-based partial decoding across 5 tile conformance streams and 1/2/4/8 threads, and partial decoding with tile index lists passed in non-ascending order. ThreadSanitizer reports no findings for multithreaded encode and decode. With a 3840x2160 stream at the RFC tile limits the scan cost is negligible, but combined with the small-tile extension in #236 (32,400 tiles of 16x16) the change reduces encode wall time from 1.3s to 0.11s and decode from 2.4s to 0.52s at 8 threads, with bit-identical results.
