### PR TITLE
Fix version extraction in release version check

### DIFF
--- a/.github/workflows/verify-release-version.yml
+++ b/.github/workflows/verify-release-version.yml
@@ -22,10 +22,10 @@ jobs:
       - name: Extract version from oapv.h
         id: header_version
         run: |
-          APISET=$(grep "^#define OAPV_VER_APISET" inc/oapv.h | awk '{print $3}')
-          MAJOR=$(grep "^#define OAPV_VER_MAJOR" inc/oapv.h | awk '{print $3}')
-          MINOR=$(grep "^#define OAPV_VER_MINOR" inc/oapv.h | awk '{print $3}')
-          PATCH=$(grep "^#define OAPV_VER_PATCH" inc/oapv.h | awk '{print $3}')
+          APISET=$(grep "^#define OAPV_VER_APISET" inc/oapv.h | awk '{print $3}' | tr -d '()')
+          MAJOR=$(grep "^#define OAPV_VER_MAJOR" inc/oapv.h | awk '{print $3}' | tr -d '()')
+          MINOR=$(grep "^#define OAPV_VER_MINOR" inc/oapv.h | awk '{print $3}' | tr -d '()')
+          PATCH=$(grep "^#define OAPV_VER_PATCH" inc/oapv.h | awk '{print $3}' | tr -d '()')
           HEADER_VERSION="${APISET}.${MAJOR}.${MINOR}.${PATCH}"
           echo "version=${HEADER_VERSION}" >> $GITHUB_OUTPUT
           echo "Header version: ${HEADER_VERSION}"


### PR DESCRIPTION
The version values in `inc/oapv.h` are parenthesized (`#define OAPV_VER_APISET (1)`), so the extraction in verify-release-version.yml produced `(1).(0).(1).(0)` and the comparison against the release tag could never succeed — every release would have failed the check. Stripping the parentheses yields `1.0.1.0` as intended (verified by running the extraction locally against the current header).
