### PR TITLE
Size bitstream buffers from resolution instead of a fixed 128 MiB

### DIFF
--- a/app/oapv_app_dec.c
+++ b/app/oapv_app_dec.c
@@ -217,11 +217,10 @@ static int read_au_size(FILE *fp, unsigned int *au_size)
     return 1;
 }
 
-static int read_bitstream(FILE *fp, unsigned char *bs_buf, int *bs_buf_size)
+static int read_bitstream(FILE *fp, unsigned char **bs_buf, int *bs_buf_cap, int *bs_buf_size)
 {
     unsigned int  au_size;
     int           read_size = 0;
-    unsigned char b = 0;
     int           ret;
     if(!fseek(fp, 0, SEEK_CUR)) {
         /* read size first */
@@ -241,20 +240,21 @@ static int read_bitstream(FILE *fp, unsigned char *bs_buf, int *bs_buf_size)
                 logerr("ERR: bitstream size (%u bytes) exceeds maximum buffer size (%d bytes)\n", au_size, MAX_BS_BUF);
                 return -1;
             }
-            while(au_size > 0) {
-                /* read byte */
-                if(1 != fread(&b, 1, 1, fp)) {
-                    logerr("ERR: Cannot read bitstream!\n");
+            /* grow the bitstream buffer only when the AU does not fit */
+            if((int)au_size > *bs_buf_cap) {
+                unsigned char *p = realloc(*bs_buf, au_size);
+                if(p == NULL) {
+                    logerr("ERR: cannot allocate bitstream buffer, size=%u\n", au_size);
                     return -1;
                 }
-                if(read_size >= MAX_BS_BUF) {
-                    logerr("ERR: bitstream buffer overflow\n");
-                    return -1;
-                }
-                bs_buf[read_size] = b;
-                read_size++;
-                au_size--;
+                *bs_buf = p;
+                *bs_buf_cap = (int)au_size;
             }
+            if(au_size != fread(*bs_buf, 1, au_size, fp)) {
+                logerr("ERR: Cannot read bitstream!\n");
+                return -1;
+            }
+            read_size = (int)au_size;
             *bs_buf_size = read_size;
         }
         else {
@@ -436,20 +436,12 @@ int dec_api_set_0(args_var_t *args_var, FILE *fp_bs, int is_y4m)
     int              i, ret = 0;
     oapv_clk_t       clk_beg, clk_end, clk_tot;
     int              au_cnt, frm_cnt[OAPV_MAX_NUM_FRAMES];
-    int              read_size, bs_buf_size = 0;
+    int              read_size, bs_buf_size = 0, bs_buf_cap = 0;
     int              prev_frm_w = -1, prev_frm_h = -1;
 
     memset(frm_cnt, 0, sizeof(int) * OAPV_MAX_NUM_FRAMES);
     memset(&aui, 0, sizeof(oapv_au_info_t));
     memset(&ofrms, 0, sizeof(oapv_frms_t));
-
-    // create bitstream buffer
-    bs_buf = malloc(MAX_BS_BUF);
-    if(bs_buf == NULL) {
-        logerr("ERR: cannot allocate bitstream buffer, size=%d\n", MAX_BS_BUF);
-        ret = -1;
-        goto ERR;
-    }
 
     // clear descriptor so unset fields (e.g. ops_mem) default to zero
     memset(&cdesc, 0, sizeof(oapvd_cdesc_t));
@@ -494,7 +486,7 @@ int dec_api_set_0(args_var_t *args_var, FILE *fp_bs, int is_y4m)
 
     /* decoding loop */
     while(args_var->max_au == 0 || (au_cnt < args_var->max_au)) {
-        read_size = read_bitstream(fp_bs, bs_buf, &bs_buf_size);
+        read_size = read_bitstream(fp_bs, &bs_buf, &bs_buf_cap, &bs_buf_size);
         if (read_size == 0) {
             logv3("--> end of bitstream\n")
             break;
@@ -568,7 +560,7 @@ int dec_api_set_0(args_var_t *args_var, FILE *fp_bs, int is_y4m)
 
         /* main decoding block */
         bitb.addr = bs_buf;
-        bitb.bsize = MAX_BS_BUF;
+        bitb.bsize = bs_buf_cap;
         bitb.ssize = bs_buf_size;
         memset(&stat, 0, sizeof(oapvd_stat_t));
 
@@ -786,14 +778,8 @@ int dec_api_set_1(args_var_t *args_var, FILE *fp_bs, int is_y4m)
     int               primary_frm_cnt = 0; // number of decoded primary frame
     int               primary_frm_gid = -1; // group id of primary frame
     unsigned char    *pbu = NULL;
+    int               pbu_cap = 0;
     int               prev_frm_w = -1, prev_frm_h = -1;
-
-    // create bitstream buffer
-    pbu = malloc(MAX_BS_BUF);
-    if(pbu == NULL) {
-        logerr("ERR: cannot allocate bitstream buffer, size=%d\n", MAX_BS_BUF);
-        ret = -1; goto ERR;
-    }
 
     if(args_var->cyclic_tile_decoding) {
         if(args_var->api_set == 0) {
@@ -880,6 +866,17 @@ int dec_api_set_1(args_var_t *args_var, FILE *fp_bs, int is_y4m)
             if(pbu_size > MAX_BS_BUF) {
                 logerr("ERR: PBU size (%u bytes) exceeds maximum buffer size (%d bytes)\n", pbu_size, MAX_BS_BUF);
                 ret = -1; goto ERR;
+            }
+
+            /* grow the PBU buffer only when the PBU does not fit */
+            if((int)pbu_size > pbu_cap) {
+                unsigned char *p = realloc(pbu, pbu_size);
+                if(p == NULL) {
+                    logerr("ERR: cannot allocate bitstream buffer, size=%u\n", pbu_size);
+                    ret = -1; goto ERR;
+                }
+                pbu = p;
+                pbu_cap = (int)pbu_size;
             }
 
             /* read a PBU */

--- a/app/oapv_app_enc.c
+++ b/app/oapv_app_enc.c
@@ -34,8 +34,51 @@
 #include "oapv_app_args.h"
 #include "oapv_app_y4m.h"
 
-#define MAX_BS_BUF   (128 * 1024 * 1024)
 #define MAX_NUM_FRMS (1)           // supports only 1-frame in an access unit
+
+/* worst-case bitstream buffer size for encoding one frame of the given
+   resolution and color format; encoding cannot overflow a buffer of the
+   returned size */
+static int enc_max_bs_buf_size(int w, int h, int cf, int *size)
+{
+    long long sz, mbs;
+    int spp2; // samples per two pixels
+
+    if(size == NULL || w <= 0 || h <= 0) return -1;
+
+    switch(cf) {
+    case OAPV_CF_YCBCR400:
+        spp2 = 2;
+        break;
+    case OAPV_CF_YCBCR420:
+        spp2 = 3;
+        break;
+    case OAPV_CF_YCBCR422:
+    case OAPV_CF_PLANAR2:
+        spp2 = 4;
+        break;
+    case OAPV_CF_YCBCR444:
+        spp2 = 6;
+        break;
+    case OAPV_CF_YCBCR4444:
+        spp2 = 8;
+        break;
+    default:
+        return -1;
+    }
+
+    // w * h * spp2 is the raw sample size in bytes (two bytes per sample),
+    // doubled as the worst-case entropy coding margin
+    sz = (long long)w * h * spp2 * 2;
+    // per-tile overhead at the smallest possible tile size (one macroblock),
+    // plus slack for the AU/frame headers and metadata
+    mbs = (long long)((w + 15) >> 4) * ((h + 15) >> 4);
+    sz += mbs * 40 + 16 * 1024;
+    if(sz > INT_MAX) return -1;
+
+    *size = (int)sz;
+    return 0;
+}
 #define FRM_IDX      (0)           // supports only 1-frame in an access unit
 #define MAX_NUM_CC   (OAPV_MAX_CC) // Max number of color components (upto 4:4:4:4)
 
@@ -911,6 +954,7 @@ int main(int argc, const char **argv)
     int            is_out = 0, is_rec = 0;
     char          *errstr = NULL;
     int            cfmt;                      // color format
+    int            bs_buf_size = 0;           // bitstream buffer size
     const int      num_frames = MAX_NUM_FRMS; // number of frames in an access unit
 
     // print logo
@@ -1032,7 +1076,13 @@ int main(int argc, const char **argv)
         goto ERR;
     }
 
-    cdesc.max_bs_buf_size = MAX_BS_BUF; /* maximum bitstream buffer size */
+    /* size the bitstream buffer from the resolution and color format */
+    if(enc_max_bs_buf_size(param->w, param->h, cfmt, &bs_buf_size)) {
+        logerr("ERR: cannot get bitstream buffer size\n");
+        ret = -1;
+        goto ERR;
+    }
+    cdesc.max_bs_buf_size = bs_buf_size; /* maximum bitstream buffer size */
     cdesc.max_num_frms = MAX_NUM_FRMS;
     if(!strcmp(args_var->threads, "auto")){
         cdesc.threads = OAPV_CDESC_THREADS_AUTO;
@@ -1076,9 +1126,9 @@ int main(int argc, const char **argv)
     }
 
     /* allocate bitstream buffer */
-    bs_buf = (unsigned char *)malloc(MAX_BS_BUF);
+    bs_buf = (unsigned char *)malloc(bs_buf_size);
     if(bs_buf == NULL) {
-        logerr("ERR: cannot allocate bitstream buffer, size=%d", MAX_BS_BUF);
+        logerr("ERR: cannot allocate bitstream buffer, size=%d", bs_buf_size);
         ret = -1;
         goto ERR;
     }
@@ -1110,7 +1160,7 @@ int main(int argc, const char **argv)
 
     bitrate_tot = 0;
     bitb.addr = bs_buf;
-    bitb.bsize = MAX_BS_BUF;
+    bitb.bsize = bs_buf_size;
 
     if(args_var->seek > 0) {
         state = STATE_SKIPPING;

--- a/src/oapv.c
+++ b/src/oapv.c
@@ -985,12 +985,20 @@ static int enc_frm_prepare(oapve_ctx_t *ctx, oapve_param_t *param, oapv_imgb_t *
     ret = enc_set_tile_info(ctx->tile, ctx->w, ctx->h, param->tile_w, param->tile_h, &ctx->num_tile_cols, &ctx->num_tile_rows, &ctx->num_tiles);
     oapv_assert_rv(OAPV_SUCCEEDED(ret), ret);
 
-    // set bitstream buffer for each tile
-    int buf_size = ctx->cdesc.max_bs_buf_size / ctx->num_tiles;
-    ctx->tile[0].bs_buf_max = buf_size;
-    for(i = 1; i < ctx->num_tiles; i++) {
-        ctx->tile[i].bs_buf = ctx->tile[i - 1].bs_buf + buf_size;
-        ctx->tile[i].bs_buf_max = buf_size;
+    // set bitstream buffer for each tile, sized in proportion to the tile
+    // area so a larger tile in a non-uniform grid gets a larger share
+    {
+        u8 *base = ctx->tile[0].bs_buf;
+        s64 area_sum = 0, off = 0;
+        for(i = 0; i < ctx->num_tiles; i++) {
+            area_sum += (s64)ctx->tile[i].w * ctx->tile[i].h;
+        }
+        for(i = 0; i < ctx->num_tiles; i++) {
+            s64 buf_size = (s64)ctx->cdesc.max_bs_buf_size * ((s64)ctx->tile[i].w * ctx->tile[i].h) / area_sum;
+            ctx->tile[i].bs_buf = base + off;
+            ctx->tile[i].bs_buf_max = (u32)buf_size;
+            off += buf_size;
+        }
     }
     // set cores
     for(i = 0; i < ctx->threads; i++) {


### PR DESCRIPTION
Fixes #146.

The encoder and decoder apps allocated fixed 128 MiB bitstream buffers regardless of the content.

**Encoder**: the app computes a worst-case buffer size from the resolution and color format (raw sample size doubled as the entropy coding margin, plus per-tile and header overhead). This is an upper bound, not an estimate, so encoding cannot fail from an undersized buffer. This is about 0.6 MB for 320x240 4:2:2 and 67 MB for 4K instead of 128 MiB. The library now also splits the buffer across tiles in proportion to the tile area instead of evenly, so a larger tile in a non-uniform grid (e.g. frame width slightly above a tile-width multiple) gets a proportionally larger share; with the even split such a tile could overflow its slice once the total buffer is sized tightly.

**Decoder**: the app allocates lazily and grows the buffer only when an AU (or PBU in API set 0) larger than the current capacity arrives, so the first allocation is exactly the first AU size and reallocation happens only when a larger AU is first seen. The 128 MiB constant remains only as a sanity cap against malformed sizes.

Verified: full test suite passes; incompressible 12-bit noise at QP 0 encodes successfully across tile configurations including a frame width just above a tile-width multiple (272 px with 256-wide tiles), which is the worst case for the proportional split; bitstreams are byte-identical to main for CQP and ABR across resolutions and tile configurations; decoder outputs are identical to main for conformance streams, API set 0, cyclic tile decoding, and a stream whose AU sizes grow mid-stream (4 KB to 300 KB), exercising the reallocation path; AddressSanitizer reports no findings on the new paths.
