### PR TITLE
Document RGB content encoding in the programmers guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ Encoding:
     oapv_app_enc -i input_1920x1080_yuv422_10bit.yuv -w 1920 -h 1080 -d 10 -z 30 --input-csp 2 -o encoded.apv
     oapv_app_enc -i input.y4m -o encoded.apv
 
+Encoding RGB content (G/B/R planar order, coded as 444 with the identity matrix signalled in the color description; see the [Programmer's Guide](/docs/programmers_guide.md) for details):
+
+    oapv_app_enc -i input_rgb_gbr_planar_10bit.yuv -w 1920 -h 1080 -d 10 -z 30 --input-csp 3 --profile 444-10 --color-primaries 1 --color-transfer 13 --color-matrix 0 --color-range 1 -o encoded.apv
+
 ### Decoder
 
 Decoder output can be in yuv or y4m formats.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The OpenAPV supports the following features:
 - Low complexity by optimization for ARM NEON and x86(64bit) SEE/AVX CPU
 - Tile-based multi-threading
 - Various metadata including HDR10/10+ and user-defined format
+- RGB content coding with the 444 profiles through color description signalling
 - Constant QP (CQP) and average bitrate (ABR) rate control algorithms
 - [APV Family](/readme/apv_family.md) configurations for typical target bitrate setting of encoder
 - [APV Profile Extensions](/docs/profile_ext.md) defined by the OpenAPV project on top of the RFC 9924 profiles
@@ -121,8 +122,8 @@ Decoding:
 
 See the [Programmer's Guide](/docs/programmers_guide.md) for how to write
 encoding and decoding code with the library, including PBU-based decoding,
-tile-based partial decoding, runtime configuration, and the custom memory
-allocator interface.
+tile-based partial decoding, runtime configuration, RGB content encoding,
+and the custom memory allocator interface.
 
 ## Utility
 

--- a/docs/programmers_guide.md
+++ b/docs/programmers_guide.md
@@ -219,14 +219,24 @@ and AV1 use, which is why no separate RGB profile exists.
 The plane order follows the ITU-T H.273 convention: G in component 0, B in
 component 1, R in component 2 (the same order as ffmpeg's `gbrp` formats).
 
-Encoding GBR-ordered planar RGB with the reference encoder:
+To encode RGB, feed the G/B/R planes as a 444 image and signal the color
+description through the encoding parameters:
 
 ```
-oapv_app_enc -i rgb_gbr_planar.yuv -w 3840 -h 2160 -z 30 -d 10 \
-  --input-csp 3 --profile 444-10 -q 20 \
-  --color-primaries 1 --color-transfer 13 --color-matrix 0 --color-range 1 \
-  -o out.oapv
+// image buffer: component 0 = G, 1 = B, 2 = R
+imgb->cs = OAPV_CS_SET(OAPV_CF_YCBCR444, 10, 0)
+
+oapve_param_default(&param)
+param.profile_idc = OAPV_PROFILE_444_10
+param.color_description_present_flag = 1
+param.color_primaries = 1           // e.g. sRGB / BT.709 primaries
+param.transfer_characteristics = 13 // e.g. sRGB transfer
+param.matrix_coefficients = 0       // identity, no YCbCr conversion
+param.full_range_flag = 1
 ```
+
+The reference encoder exposes the same controls; see the encoding examples
+in the README.
 
 On the decoding side, a 444 stream with `color_description_present_flag` set
 and `matrix_coefficients == 0` (reported by `oapvd_info()` and in

--- a/docs/programmers_guide.md
+++ b/docs/programmers_guide.md
@@ -201,6 +201,38 @@ oapvd_decode_frame(did, &bitb, imgb, &stat, num_part_tiles, part_tile_idxs)
 Passing `0, NULL` decodes every tile. The regions of unselected tiles are
 left untouched, so clear or reuse the image buffer accordingly.
 
+## Encoding RGB content
+
+The 444 profiles do not prescribe a color space: the three planes are just
+components 0/1/2, and the color space interpretation is carried by the color
+description fields of the frame header. RGB content is therefore coded with a
+444 profile plus an identity matrix signal — the same convention HEVC, VP9,
+and AV1 use, which is why no separate RGB profile exists.
+
+| field | value for RGB | meaning |
+|---|---|---|
+| `matrix_coefficients` | 0 | identity matrix, no YCbCr conversion |
+| `color_primaries` | per content (e.g. sRGB/BT.709 = 1, BT.2020 = 9) | primaries |
+| `transfer_characteristics` | per content (e.g. sRGB = 13, PQ = 16) | transfer function |
+| `full_range_flag` | usually 1 | RGB is normally full range |
+
+The plane order follows the ITU-T H.273 convention: G in component 0, B in
+component 1, R in component 2 (the same order as ffmpeg's `gbrp` formats).
+
+Encoding GBR-ordered planar RGB with the reference encoder:
+
+```
+oapv_app_enc -i rgb_gbr_planar.yuv -w 3840 -h 2160 -z 30 -d 10 \
+  --input-csp 3 --profile 444-10 -q 20 \
+  --color-primaries 1 --color-transfer 13 --color-matrix 0 --color-range 1 \
+  -o out.oapv
+```
+
+On the decoding side, a 444 stream with `color_description_present_flag` set
+and `matrix_coefficients == 0` (reported by `oapvd_info()` and in
+`oapvd_stat_t`) identifies RGB content; the decoded planes are G, B, and R
+as coded, with no conversion applied.
+
 ## Custom memory allocator
 
 By default the library allocates with the standard C library. An application


### PR DESCRIPTION
Adds an "Encoding RGB content" section to the programmers guide, addressing the question raised in #102.

RGB is coded with a 444 profile plus the identity matrix signal in the color description (the same convention as HEVC/VP9/AV1, hence no separate RGB profile), with H.273 GBR plane ordering. The section documents the field values, a reference encoder command line, and how a decoder identifies RGB content. Verified with a round trip: the reference encoder writes the color description (1/13/0/1) into the stream and `oapvd_info()` reports it back.

Also surfaces RGB support in the README: a features list entry and a mention in the programmers guide summary.
