### PR TITLE
Use the luma dead zone for all components of RGB and 16C12 content

### DIFF
--- a/src/oapv.c
+++ b/src/oapv.c
@@ -267,7 +267,7 @@ static double enc_block(oapve_ctx_t *ctx, oapve_core_t *core, int log2_w, int lo
     int bit_depth = ctx->bit_depth;
 
     oapv_trans(ctx, core->coef, log2_w, log2_h, bit_depth);
-    ctx->fn_quant[0](core->coef, core->qp[c], core->q_mat_enc[c], log2_w, log2_h, bit_depth, c ? 128 : 212);
+    ctx->fn_quant[0](core->coef, core->qp[c], core->q_mat_enc[c], log2_w, log2_h, bit_depth, ctx->dz[c]);
 
     core->dc_diff = core->coef[0] - core->prev_dc[c];
     core->prev_dc[c] = core->coef[0];
@@ -948,6 +948,16 @@ static int enc_frm_prepare(oapve_ctx_t *ctx, oapve_param_t *param, oapv_imgb_t *
     ctx->qp_offset[U_C] = param->qp_offset_c1;
     ctx->qp_offset[V_C] = param->qp_offset_c2;
     ctx->qp_offset[X_C] = param->qp_offset_c3;
+
+    // identity matrix (RGB) content gets the luma dead zone for all color
+    // components while alpha keeps the chroma value; the 16C12 profiles carry
+    // co-equal raw sensor channels (e.g. RGGB), so every component gets the
+    // luma dead zone
+    int is_rgb = param->color_description_present_flag && param->matrix_coefficients == 0;
+    int is_c16 = param->profile_idc == OAPV_PROFILE_444_16C12 || param->profile_idc == OAPV_PROFILE_4444_16C12;
+    ctx->dz[Y_C] = 212;
+    ctx->dz[U_C] = ctx->dz[V_C] = (is_rgb || is_c16) ? 212 : 128;
+    ctx->dz[X_C] = is_c16 ? 212 : 128;
 
     for(i = 0; i < N_C; i++) {
         ctx->qp[i] = oapv_clip3(MIN_QUANT, MAX_QUANT(ctx->bit_depth), param->qp + ctx->qp_offset[i]);

--- a/src/oapv_def.h
+++ b/src/oapv_def.h
@@ -309,6 +309,7 @@ struct oapve_ctx {
     int                        num_tile_rows;
     int                        qp[N_C];
     s8                         qp_offset[N_C];
+    int                        dz[N_C]; // quantization rounding offset per component
     int                        w;
     int                        h;
     int                        cfi;


### PR DESCRIPTION
The fast-preset quantization applied a smaller rounding offset (larger dead zone) to components 1 and 2 than to component 0, hardcoded by component index. That is the intended luma/chroma trade-off for YCbCr, but it treats content unequally when the components are co-equal: for RGB coded with the identity matrix the B and R planes were quantized more aggressively than G, and for the 16C12 profiles, which carry co-equal raw sensor channels (e.g. RGGB), three of the four channels were penalized.

The rounding offsets now come from a per-component table set at frame preparation: identity-matrix (RGB) content gets the luma value for all color components while alpha keeps the chroma value, and the 16C12 profiles get the luma value for every component. YCbCr behavior is unchanged.

Only the fast and fastest presets are affected; the RDOQ path used by the medium and higher presets already treats all components equally.

Verified: YCbCr bitstreams (including 4444 with alpha) are byte-identical to main across presets; RGB and 16C12 bitstreams change only on the fast presets as intended; the full test suite passes; interleaved timing on the fastest preset shows no measurable speed difference (the compile-time constant becomes one cached table load per block).

Measured effect on 4444-16C12 raw-style content (fastest preset, q 30): per-channel PSNR goes from 46.98 / 45.55 / 45.71 / 45.91 dB on main (channels 1-3 penalized by the chroma dead zone) to 46.98 / 46.92 / 47.08 / 47.27 dB with this change — the channel spread drops from 1.43 dB to 0.35 dB with channel 0 unchanged.
