### PR TITLE
Report the bitstream location of each tile from oapvd_info_tile

### DIFF
--- a/inc/oapv.h
+++ b/inc/oapv.h
@@ -477,6 +477,8 @@ struct oapv_tile_pos {
     int y_mb; /* y-position in MB unit */
     int w_mb; /* width in MB unit */
     int h_mb; /* height in MB unit */
+    int offset; /* byte offset of the tile from the start of the PBU */
+    int size;   /* byte size of the tile data; 0 if the frame header does not carry the tile sizes */
 };
 
 /*****************************************************************************

--- a/readme/programmers_guide.md
+++ b/readme/programmers_guide.md
@@ -201,6 +201,50 @@ oapvd_decode_frame(did, &bitb, imgb, &stat, num_part_tiles, part_tile_idxs)
 Passing `0, NULL` decodes every tile. The regions of unselected tiles are
 left untouched, so clear or reuse the image buffer accordingly.
 
+When the frame header carries the tile sizes (the encoder writes them by
+default; see `OAPV_CFG_SET_TILE_SIZE_IN_FH`), `oapvd_info_tile()` also
+reports where each tile lives in the PBU, so an application can seek to a
+tile instead of scanning the whole PBU:
+
+```
+oapvd_info_tile(pbu_buf, pbu_size, pos, &num)
+
+// pos[i].offset  byte offset of the tile unit from the start of the PBU
+// pos[i].size    byte size of the tile data
+// the tile unit spans 4 + size bytes: a 4-byte size field, then the data
+
+read(input, tile_buf, 4 + pos[i].size, at pos[i].offset)  // one tile only
+```
+
+Both fields are zero when the frame header does not carry the tile sizes, so
+a zero `size` means the location is unknown and the PBU has to be walked
+sequentially. This pairs with a memory-mapped input: only the pages of the
+tiles that are actually decoded are touched.
+
+Whether the locations are available depends on the bitstream, so treat them
+as optional:
+
+- `tile_size_present_in_fh_flag` is a per-frame choice of the encoder. This
+  encoder sets it by default and it can be turned off per frame with
+  `OAPV_CFG_SET_TILE_SIZE_IN_FH`, and a stream from another encoder may not
+  carry the sizes at all. Check `size` before relying on a location, and
+  keep the sequential path for streams that report zero.
+- The values are relative to the start of the frame PBU, not to the file or
+  the access unit. An application that reads from a file adds the position
+  where the PBU begins, which is after the 4-byte `au_size`, the `aPv1`
+  signature, and the 4-byte `pbu_size` of that PBU.
+- They describe only the tile data of that frame PBU. Metadata PBUs and
+  other frames of the same access unit are separate PBUs, so their contents
+  are not covered by these values.
+- The tile order is the raster scan order of the tile grid, the same order
+  as `idx`, and the tile units are contiguous, so the end of the last tile
+  coincides with the end of the PBU.
+- The values come from the bitstream, and the decoder rejects a frame whose
+  tile sizes do not fit within the PBU, so a successful call reports
+  locations that lie inside the PBU. Beyond that, an application that
+  forwards them to its I/O layer should still bound-check against the size
+  of the buffer or mapping it actually holds.
+
 ## Encoding RGB content
 
 The 444 profiles do not prescribe a color space: the three planes are just

--- a/src/oapv.c
+++ b/src/oapv.c
@@ -2376,8 +2376,15 @@ int oapvd_info_tile(void *pbu, int pbu_size, oapv_tile_pos_t *pos_tiles, int *nu
     // check frame type PBU
     oapv_assert_gv(OAPV_PBU_TYPE_IS_FRAME(pbuh.pbu_type), ret, OAPV_ERR_INVALID_ARGUMENT, ERR);
 
-    // decode frame header
-    ret = oapvd_vlc_frame_header(&bs, &fh);
+    // decode frame header; the tile sizes it may carry are reported into the
+    // caller's array, which must be cleared first since they are optional
+    if(pos_tiles != NULL) {
+        for(i = 0; i < *num_tiles; i++) {
+            pos_tiles[i].offset = 0;
+            pos_tiles[i].size = 0;
+        }
+    }
+    ret = oapvd_vlc_frame_header_ex(&bs, &fh, pos_tiles, (pos_tiles != NULL) ? *num_tiles : 0);
     oapv_assert_g(OAPV_SUCCEEDED(ret), ERR);
 
     pic_w_mb = (fh.fi.frame_width + (OAPV_MB_W - 1)) >> OAPV_LOG2_MB_W;
@@ -2421,6 +2428,17 @@ int oapvd_info_tile(void *pbu, int pbu_size, oapv_tile_pos_t *pos_tiles, int *nu
             }
             tpos->idx = i * tile_cols + j;
             tpos++;
+        }
+    }
+    if(fh.tile_size_present_in_fh_flag) {
+        // tile data follows the frame header; each tile unit is a 4-byte size
+        // field plus the tile data of the size reported above
+        s64 off = BSR_GET_READ_BYTE(&bs);
+        for(i = 0; i < n; i++) {
+            off += OAPV_TILE_SIZE_LEN + pos_tiles[i].size;
+            // the tile must lie within the PBU
+            oapv_assert_gv(off <= (s64)pbu_size, ret, OAPV_ERR_MALFORMED_BITSTREAM, ERR);
+            pos_tiles[i].offset = (int)(off - OAPV_TILE_SIZE_LEN - pos_tiles[i].size);
         }
     }
     *num_tiles = n;

--- a/src/oapv_vlc.c
+++ b/src/oapv_vlc.c
@@ -813,7 +813,7 @@ static int dec_vlc_q_matrix(oapv_bs_t *bs, oapv_fh_t *fh)
     return OAPV_OK;
 }
 
-static int dec_vlc_tile_info(oapv_bs_t *bs, oapv_fh_t *fh)
+static int dec_vlc_tile_info(oapv_bs_t *bs, oapv_fh_t *fh, oapv_tile_pos_t *pos_tiles, int cap)
 {
     int ret;
     int pic_w, pic_h, tile_w, tile_h, tile_cols, tile_rows;
@@ -843,10 +843,16 @@ static int dec_vlc_tile_info(oapv_bs_t *bs, oapv_fh_t *fh)
     DUMP_HLS(fh->tile_size_present_in_fh_flag, fh->tile_size_present_in_fh_flag);
 
     if(fh->tile_size_present_in_fh_flag) {
-        for(int i = 0; i < tile_cols * tile_rows; i++) {
-            u32 tile_size = oapv_bsr_read(bs, 32); // parsed for validation only
+        int num_tiles = tile_cols * tile_rows;
+        for(int i = 0; i < num_tiles; i++) {
+            u32 tile_size = oapv_bsr_read(bs, 32);
             DUMP_HLS(fh->tile_size, tile_size);
             oapv_assert_rv(tile_size > 0, OAPV_ERR_MALFORMED_BITSTREAM);
+            // report the size to the caller, if it asked for it
+            if(pos_tiles != NULL && cap >= num_tiles) {
+                oapv_assert_rv(tile_size <= (u32)INT_MAX, OAPV_ERR_MALFORMED_BITSTREAM);
+                pos_tiles[i].size = (int)tile_size;
+            }
         }
     }
     return OAPV_OK;
@@ -1108,6 +1114,11 @@ int oapvd_vlc_au_info(oapv_bs_t *bs, oapv_aui_t *aui)
 
 int oapvd_vlc_frame_header(oapv_bs_t *bs, oapv_fh_t *fh)
 {
+    return oapvd_vlc_frame_header_ex(bs, fh, NULL, 0);
+}
+
+int oapvd_vlc_frame_header_ex(oapv_bs_t *bs, oapv_fh_t *fh, oapv_tile_pos_t *pos_tiles, int cap)
+{
     int ret, reserved_zero;
     ret = oapvd_vlc_frame_info(bs, &fh->fi);
     oapv_assert_rv(OAPV_SUCCEEDED(ret), ret);
@@ -1142,7 +1153,7 @@ int oapvd_vlc_frame_header(oapv_bs_t *bs, oapv_fh_t *fh)
         oapv_assert_rv(OAPV_SUCCEEDED(ret), ret);
     }
 
-    ret = dec_vlc_tile_info(bs, fh);
+    ret = dec_vlc_tile_info(bs, fh, pos_tiles, cap);
     oapv_assert_rv(OAPV_SUCCEEDED(ret), ret);
 
     reserved_zero = oapv_bsr_read(bs, 8);

--- a/src/oapv_vlc.h
+++ b/src/oapv_vlc.h
@@ -61,6 +61,8 @@ int  oapvd_vlc_pbu_header(oapv_bs_t* bs, oapv_pbuh_t* pbuh);
 int  oapvd_vlc_au_info(oapv_bs_t* bs, oapv_aui_t* aui);
 
 int  oapvd_vlc_frame_header(oapv_bs_t* bs, oapv_fh_t* fh);
+/* variant reporting the per-tile sizes of the frame header, when present */
+int  oapvd_vlc_frame_header_ex(oapv_bs_t* bs, oapv_fh_t* fh, oapv_tile_pos_t* pos_tiles, int cap);
 int  oapvd_vlc_frame_info(oapv_bs_t* bs, oapv_fi_t *fi);
 int  oapvd_vlc_tile_size(oapv_bs_t *bs, u32 *tile_size);
 int  oapvd_vlc_tile_header(oapv_bs_t *bs, int num_comp, oapv_th_t *th, u32 tiles_data_size, int bit_depth);


### PR DESCRIPTION
Requested in #228: seeking directly to a tile requires knowing where it is in the bitstream, which the API did not expose. The frame header already carries the tile sizes when `tile_size_present_in_fh_flag` is set (written by default since #238), but the decoder parsed them for validation only and discarded them.

`oapv_tile_pos_t` gains two fields, filled by `oapvd_info_tile()`:

- `offset` — byte offset of the tile unit from the start of the PBU
- `size` — byte size of the tile data

A tile unit spans `4 + size` bytes: the 4-byte size field followed by the tile data. Both fields are zero when the frame header does not carry the tile sizes, so a zero `size` means the location is unknown and the PBU has to be walked sequentially. The sizes are reported into the caller-supplied array, so nothing is allocated and the existing capacity-check contract of `oapvd_info_tile()` is unchanged; the frame header parser gained an internal variant that reports the sizes, with the existing entry point delegating to it.

This is what makes the memory-mapped input path in the programmers guide practical for partial decoding: only the pages of the tiles actually decoded are touched, instead of paging in the whole PBU.

The guide documents the assumptions an application has to make about these values, since they are optional and relative:

- availability is a per-frame choice of the encoder (`tile_size_present_in_fh_flag`, on by default here, switchable with `OAPV_CFG_SET_TILE_SIZE_IN_FH`), and a stream from another encoder may not carry the sizes at all, so `size` has to be checked and the sequential path kept
- the values are relative to the start of the frame PBU, not to the file or the access unit, so a file reader adds the position where the PBU begins (past `au_size`, the `aPv1` signature and that PBU's `pbu_size`)
- they describe only the tile data of that frame PBU; metadata PBUs and other frames of the same access unit are separate PBUs
- tiles are reported in raster scan order and their units are contiguous, so the end of the last tile coincides with the end of the PBU
- a successful call reports locations inside the PBU, because the decoder now rejects a frame whose tile sizes do not fit within it, but an application forwarding them to its I/O layer should still bound-check against the buffer or mapping it actually holds

Malformed tile sizes are rejected with `OAPV_ERR_MALFORMED_BITSTREAM`: the accumulated tile extent is validated against `pbu_size` while the offsets are computed.

Verified against the real bitstream layout with a harness that re-reads the 4-byte size field at every reported offset and checks it equals the reported size and stays inside the PBU: 2-tile, 135-tile (4K), 255-tile, 400-tile and 32,400-tile (UNCONST 16x16) streams, plus a non-uniform tile grid; in every case the end of the last tile lands exactly on the PBU size. Streams encoded with `--disable-tile-size-in-fh` and the conformance streams without tile sizes report zeros. All 18 ctest cases pass.

