### PR TITLE
Note that oapvd_info_tile can report the tile count on its own

### DIFF
--- a/readme/programmers_guide.md
+++ b/readme/programmers_guide.md
@@ -189,6 +189,9 @@ pos = malloc(finfo.num_tiles * sizeof(oapv_tile_pos_t))
 num = finfo.num_tiles
 oapvd_info_tile(pbu_buf, pbu_size, pos, &num)
 
+// oapvd_info_tile() can report the count on its own as well, by passing a
+// NULL tile array:  num = 0; oapvd_info_tile(pbu_buf, pbu_size, NULL, &num)
+
 // select the tiles to decode, e.g. the ones covering a viewport
 part_tile_idxs = { 3, 4, 7, 8 }
 num_part_tiles = 4


### PR DESCRIPTION
Follow-up to #260. The tile example in the programmers guide sizes the array from `oapvd_info_frame()`, which is the usual path; this notes that `oapvd_info_tile()` can also report the count on its own when the caller passes a NULL tile array, so an application that only needs the tile array does not have to call both. Documentation only.
