### PR TITLE
Allow DC coefficient differences beyond 16 bits and validate the reconstructed value

### DIFF
--- a/src/oapv.c
+++ b/src/oapv.c
@@ -1569,8 +1569,10 @@ static int dec_block(oapvd_ctx_t *ctx, oapvd_core_t *core, int log2_w, int log2_
 {
     int bit_depth = ctx->bit_depth;
 
-    // DC prediction
-    core->coef[0] = core->dc_diff + core->prev_dc[c];
+    // DC prediction; the reconstructed value must fit the coefficient range
+    int dc = core->dc_diff + core->prev_dc[c];
+    oapv_assert_rv(dc >= MIN_TX_VAL && dc <= MAX_TX_VAL, OAPV_ERR_MALFORMED_BITSTREAM);
+    core->coef[0] = (s16)dc;
     core->prev_dc[c] = core->coef[0];
     // Inverse quantization
     ctx->fn_dquant[0](core->coef, core->q_mat[c], log2_w, log2_h, core->dq_shift[c]);

--- a/src/oapv_vlc.c
+++ b/src/oapv_vlc.c
@@ -866,12 +866,15 @@ int oapvd_vlc_dc_coef(oapv_bs_t *bs, int *dc_diff, int *kparam_dc)
     abs_dc_diff = dec_vlc_read(bs, *kparam_dc);
     if(abs_dc_diff < 0) // dec_vlc_read error sentinel
         return OAPV_ERR_MALFORMED_BITSTREAM;
-    if(abs_dc_diff > 32767)
+    // DC coefficients are in [-32768, 32767], so the difference between two
+    // neighboring blocks can legally reach 65535; only the reconstructed DC
+    // value is bounded, which dec_block() checks after prediction
+    if(abs_dc_diff > 65535)
         return OAPV_ERR_MALFORMED_BITSTREAM;
     if(abs_dc_diff) {
         if(bs->leftbits == 0) BSR_FLUSH_1BYTE(bs);
         BSR_READ_1BIT(bs, sign);
-        *dc_diff = oapv_set_sign16(abs_dc_diff, sign);
+        *dc_diff = oapv_set_sign(abs_dc_diff, sign);
         *kparam_dc = KPARAM_DC(abs_dc_diff);
     }
     else {


### PR DESCRIPTION
Fixes #254.

DC coefficients are in `[-32768, 32767]`, so the difference between two neighboring blocks can legally reach 65535. RFC 9924 places the range constraint on the reconstructed coefficient, not on the difference, and the encoder writes such differences without any bound. The decoder rejected them, so it failed to decode conforming streams produced by its own encoder — 12-bit at QP 0-4, and any bit depth with a custom quantization matrix.

`oapvd_vlc_dc_coef()`: raise the `abs_dc_diff` limit from 32767 to 65535, and apply the sign with `oapv_set_sign()` instead of the misleadingly named `oapv_set_sign16()` (both operate on `int`, so this is a rename, not a behavior change).

`dec_block()`: compute the predicted DC in `int` and validate it against `MIN_TX_VAL`/`MAX_TX_VAL` before storing to the `s16` coefficient buffer. This is where the range constraint belongs, and it also closes a pre-existing overflow: the old code summed two `int` values into an `s16` with no check, so a value up to 65534 could wrap silently.
