### PR TITLE
Reset the shared tile counter so oapvd_decode_frame() works more than once

### DIFF
--- a/src/oapv.c
+++ b/src/oapv.c
@@ -1717,6 +1717,7 @@ static int dec_frm_prepare(oapvd_ctx_t *ctx, int num_part_tiles, const int *part
         ctx->tile[i].bs_beg = NULL;
     }
     ctx->tile[0].bs_beg = oapv_bsr_sink(&ctx->bs);
+    ctx->tile_idx = 0;
 
     if(num_part_tiles > 0) {
         oapv_assert_rv(part_tile_idxs != NULL, OAPV_ERR_INVALID_ARGUMENT);


### PR DESCRIPTION
`oapvd_decode_frame()` decoded nothing on its second and later calls on the
same decoder: it returned `OAPV_OK` while leaving the output buffer untouched.

`ctx->tile_idx` is the counter the worker threads take tiles from. It is reset
in `oapvd_decode()` but not on this path, so after the first call it already
sat at `num_tiles` and every worker left its loop immediately.

Reset it in `dec_frm_prepare()`, beside the other per-frame tile state.
