### PR TITLE
Add oapvd_decode_tiles() for decoding selected tiles into per-tile buffers

### DIFF
--- a/app/oapv_app_dec.c
+++ b/app/oapv_app_dec.c
@@ -745,6 +745,47 @@ static int read_pbu(FILE *fp, unsigned char *pbu, unsigned int pbu_size)
     return 0;
 }
 
+/* Aim the cyclic selection's tiles at their own positions inside 'imgb', so a
+   selective decode fills the same buffer a full-frame decode would. A tile's
+   samples land at the origin of its destination, hence the per-plane bias. */
+static int set_tile_reqs(oapv_tile_req_t *reqs, int num_reqs, int frm_cnt,
+                         const oapv_frm_info_t *finfo, const oapv_imgb_t *imgb)
+{
+    int bd = OAPV_CS_GET_BYTE_DEPTH(imgb->cs);
+
+    if(finfo->tile_cols <= 0 || finfo->num_tiles <= 0) {
+        return -1;
+    }
+
+    memset(reqs, 0, sizeof(oapv_tile_req_t) * num_reqs);
+
+    for(int k = 0; k < num_reqs; k++) {
+        int idx = (frm_cnt * num_reqs + k) % finfo->num_tiles;
+        int x = (idx % finfo->tile_cols) * finfo->tile_width_in_mbs * OAPV_MB_W;
+        int y = (idx / finfo->tile_cols) * finfo->tile_height_in_mbs * OAPV_MB_H;
+
+        reqs[k].idx = idx;
+        reqs[k].imgb.cs = imgb->cs;
+
+        for(int p = 0; p < imgb->np; p++) {
+            // a subsampled plane is half as wide or half as tall; interleaved
+            // chroma keeps the luma width, its two components sharing a row
+            int sft_w = (imgb->w[p] < imgb->w[0]) ? 1 : 0;
+            int sft_h = (imgb->h[p] < imgb->h[0]) ? 1 : 0;
+            int off = ((y >> sft_h) * imgb->s[p]) + ((x >> sft_w) * bd);
+
+            if(off < 0 || off >= imgb->bsize[p]) {
+                return -1;
+            }
+            reqs[k].imgb.a[p] = (unsigned char *)imgb->a[p] + off;
+            reqs[k].imgb.s[p] = imgb->s[p];
+            reqs[k].imgb.bsize[p] = imgb->bsize[p] - off;
+        }
+    }
+
+    return 0;
+}
+
 static const char * get_key_from_val(const oapv_dict_str_int_t * dict, int val)
 {
     while(strlen(dict->key) > 0) {
@@ -763,8 +804,8 @@ int dec_api_set_1(args_var_t *args_var, FILE *fp_bs, int is_y4m)
     oapv_au_info_t    aui;
     oapvd_stat_t      stat;
     oapv_bitb_t       bitb;
-    int              *part_tile_idxs = NULL;
-    int               part_tile_cap = 0;
+    oapv_tile_req_t  *tile_reqs = NULL;
+    int               tile_req_cap = 0;
     int               num_part_tiles = 0;
 
     oapv_imgb_t      *imgb_dec = NULL;
@@ -944,17 +985,18 @@ int dec_api_set_1(args_var_t *args_var, FILE *fp_bs, int is_y4m)
                     if(num_part_tiles > finfo.num_tiles) {
                         num_part_tiles = finfo.num_tiles;
                     }
-                    if(part_tile_cap < num_part_tiles) {
-                        free(part_tile_idxs);
-                        part_tile_idxs = malloc(sizeof(int) * num_part_tiles);
-                        if(part_tile_idxs == NULL) {
-                            logerr("ERR: cannot allocate tile index buffer\n");
+                    if(tile_req_cap < num_part_tiles) {
+                        free(tile_reqs);
+                        tile_reqs = malloc(sizeof(oapv_tile_req_t) * num_part_tiles);
+                        if(tile_reqs == NULL) {
+                            logerr("ERR: cannot allocate tile request buffer\n");
                             ret = -1; goto ERR;
                         }
-                        part_tile_cap = num_part_tiles;
+                        tile_req_cap = num_part_tiles;
                     }
-                    for(int k = 0; k < num_part_tiles; k++) {
-                        part_tile_idxs[k] = (primary_frm_cnt * num_part_tiles + k) % finfo.num_tiles;
+                    if(set_tile_reqs(tile_reqs, num_part_tiles, primary_frm_cnt, &finfo, imgb_dec)) {
+                        logerr("ERR: cannot address the tiles of the decoding buffer\n");
+                        ret = -1; goto ERR;
                     }
 
                     // clear image buffer to remove previous frame's decoded tile image
@@ -968,7 +1010,12 @@ int dec_api_set_1(args_var_t *args_var, FILE *fp_bs, int is_y4m)
 
                 clk_beg = oapv_clk_get();
 
-                ret = oapvd_decode_frame(did, &bitb, imgb_dec, &stat, num_part_tiles, part_tile_idxs);
+                if(args_var->cyclic_tile_decoding) {
+                    ret = oapvd_decode_tiles(did, &bitb, num_part_tiles, tile_reqs);
+                }
+                else {
+                    ret = oapvd_decode_frame(did, &bitb, imgb_dec, &stat, 0, NULL);
+                }
 
                 clk_end = oapv_clk_from(clk_beg);
                 clk_tot += clk_end;
@@ -977,7 +1024,9 @@ int dec_api_set_1(args_var_t *args_var, FILE *fp_bs, int is_y4m)
                     logerr("ERR: failed to decode a frame (ret = %d)\n", ret);
                     ret = -1; goto ERR;
                 }
-                if(stat.read != pbu_size) {
+                // oapvd_decode_tiles() reports no read size, having been given the
+                // tiles to read rather than the whole frame
+                if(!args_var->cyclic_tile_decoding && stat.read != pbu_size) {
                     logerr("\t=> different reading of bitstream (in:%d, read:%d)\n",
                            pbu_size, stat.read);
                 }
@@ -1068,7 +1117,7 @@ ERR:
     if(pbu != NULL)
         free(pbu);
 
-    free(part_tile_idxs);
+    free(tile_reqs);
 
     return 0;
 }

--- a/app/oapv_app_dec.c
+++ b/app/oapv_app_dec.c
@@ -821,11 +821,6 @@ int dec_api_set_1(args_var_t *args_var, FILE *fp_bs, int is_y4m)
     int               pbu_cap = 0;
     int               prev_frm_w = -1, prev_frm_h = -1;
 
-    if(args_var->cyclic_tile_decoding && args_var->api_set == 0) {
-        logerr("ERR: cyclic tile-based decoding cannot be supported in API set 0\n");
-        ret = -1; goto ERR;
-    }
-
     // clear descriptor so unset fields (e.g. ops_mem) default to zero
     memset(&cdesc, 0, sizeof(oapvd_cdesc_t));
 
@@ -1177,6 +1172,13 @@ int main(int argc, const char **argv)
         args->get_int(args, "cyclic-tile-decoding", &cyc_val, &cyc_flag);
         if(cyc_flag && cyc_val <= 0) {
             logerr("ERR: invalid cyclic-tile-decoding value (%d)\n", cyc_val);
+            ret = -1;
+            goto ERR;
+        }
+        // only API set 1 reaches oapvd_decode_tiles(), so the option would be
+        // silently ignored anywhere else
+        if(cyc_flag && args_var->api_set != 1) {
+            logerr("ERR: cyclic tile-based decoding is only supported in API set 1\n");
             ret = -1;
             goto ERR;
         }

--- a/inc/oapv.h
+++ b/inc/oapv.h
@@ -864,6 +864,41 @@ OAPV_EXPORT int oapvd_info_tile(void *pbu, int pbu_size, oapv_tile_pos_t *pos_ti
 OAPV_EXPORT int oapvd_decode_auinfo(oapvd_t did, oapv_bitb_t *bitb, oapv_au_info_t *aui);
 OAPV_EXPORT int oapvd_decode_frame(oapvd_t did, oapv_bitb_t *bitb, oapv_imgb_t *imgb, oapvd_stat_t *stat, int num_part_tiles, const int *part_tile_idxs);
 
+/*****************************************************************************
+ * selective tile decoding
+ *
+ * Decodes a chosen set of tiles of one frame, each into its own buffer sized to
+ * a tile instead of to the picture. 'bitb' carries a single frame PBU, as it
+ * does for oapvd_decode_frame(), and oapvd_info_tile() reports the tile indices
+ * and dimensions needed to plan a selection.
+ *
+ * oapvd_decode_frame() also takes a tile subset, but decodes into a
+ * scanline-strided oapv_imgb_t sized to the whole picture, so a partial decode
+ * of a large frame still has to allocate that picture.
+ *****************************************************************************/
+
+/* destination of one decoded tile. unlike oapv_imgb_t this describes a tile and
+   not a picture: the tile's dimensions come from the frame header, so only the
+   address and the row stride of each component are the caller's to state. */
+typedef struct oapv_imgb_tile oapv_imgb_tile_t;
+struct oapv_imgb_tile {
+    int   cs;                 /* color space */
+    void *a[OAPV_MAX_CC];     /* address of each component */
+    int   s[OAPV_MAX_CC];     /* buffer stride (in unit of byte) */
+    int   bsize[OAPV_MAX_CC]; /* buffer size behind a[c], or 0 to skip the check */
+};
+
+typedef struct oapv_tile_req oapv_tile_req_t;
+struct oapv_tile_req {
+    int              idx; /* tile index in raster scan order */
+    oapv_imgb_tile_t imgb;
+};
+
+/* Every destination must carry the same color space, and it must correspond to
+   the bitstream's chroma format as it must for oapvd_decode_frame(). A tile
+   index appearing twice is rejected rather than decoded twice. */
+OAPV_EXPORT int oapvd_decode_tiles(oapvd_t did, oapv_bitb_t *bitb, int num_tiles, oapv_tile_req_t *tile_reqs);
+
 
 
 #ifdef __cplusplus

--- a/readme/programmers_guide.md
+++ b/readme/programmers_guide.md
@@ -421,6 +421,94 @@ as optional:
   forwards them to its I/O layer should still bound-check against the size
   of the buffer or mapping it actually holds.
 
+### Decoding tiles into buffers of their own
+
+`oapvd_decode_frame()` decodes a tile subset, but its output is one
+scanline-strided `oapv_imgb_t` sized to the whole picture, so a partial
+decode of a large frame still has to allocate that picture.
+`oapvd_decode_tiles()` gives each tile a destination of its own:
+
+```
+oapvd_decode_tiles(did, &bitb, num_tiles, tile_reqs)
+```
+
+`bitb` carries a single frame PBU, the same input `oapvd_decode_frame()`
+takes. Each entry of `tile_reqs` names a tile and says where to put it:
+
+```
+struct oapv_tile_req {
+    int              idx;   // tile index in raster scan order
+    oapv_imgb_tile_t imgb;  // where this tile goes
+};
+
+struct oapv_imgb_tile {
+    int   cs;                 // color space
+    void *a[OAPV_MAX_CC];     // address of each component
+    int   s[OAPV_MAX_CC];     // buffer stride, in bytes
+    int   bsize[OAPV_MAX_CC]; // buffer size behind a[c], or 0 to skip the check
+};
+```
+
+`oapv_imgb_tile_t` describes a tile rather than a picture: the tile's
+dimensions come from the frame header, so only the address and the row
+stride of each component are the application's to state. The samples of a
+tile land at its buffer's origin, not at the tile's position in the frame.
+
+```
+// plan the selection from the tile grid
+num = finfo.num_tiles
+pos = malloc(num * sizeof(oapv_tile_pos_t))
+oapvd_info_tile(pbu_buf, pbu_size, pos, &num)
+
+// one slot per tile, all inside a single allocation
+for(i = 0; i < num_wanted; i++) {
+    reqs[i].idx     = wanted[i]
+    reqs[i].imgb.cs = finfo.cs
+    for(c = 0; c < num_comp; c++) {
+        reqs[i].imgb.a[c]     = slot_address(arena, i, c)
+        reqs[i].imgb.s[c]     = tile_width(c) * 2
+        reqs[i].imgb.bsize[c] = reqs[i].imgb.s[c] * tile_height(c)
+    }
+}
+
+oapvd_decode_tiles(did, &bitb, num_wanted, reqs)
+```
+
+Because each request carries its own addresses, the application decides
+where a tile lands. Pointing them into one arena gives an output sized to
+the number of tiles asked for rather than to the frame's tile count, which
+is what a viewport-driven client wants. Pointing them into a picture-sized
+buffer, at each tile's own position, reproduces what
+`oapvd_decode_frame()` does with `part_tile_idxs`.
+
+What the call requires:
+
+- Every destination must carry the same `cs`, and it must correspond to the
+  bitstream's `chroma_format_idc`, exactly as `oapv_imgb_t.cs` must for
+  `oapvd_decode_frame()`.
+- `idx` must be within the frame's tile count, and no tile may be asked for
+  twice.
+- `s[c]` must be at least the tile's row of component `c`. Interleaved
+  chroma (`OAPV_CF_PLANAR2`) keeps Cb and Cr in the same row of the same
+  plane, so that row is twice as wide.
+- `bsize[c]` is optional, as `oapv_bitb_t.bsize` is: give the capacity
+  behind `a[c]` to have it checked, or zero to skip the check.
+- Edge tiles are clipped by the frame, so they are smaller than the tile
+  size in the frame header. `oapvd_info_tile()` reports each tile's actual
+  `w_mb` and `h_mb`.
+
+The tiles are decoded in ascending index order. Tile data is laid out in
+that order too, so the bitstream is read front to back rather than jumped
+back and forth in — which matters most when the input is a memory mapping.
+When the frame header carries the tile sizes, every tile is located from the
+header alone and the tiles that were not asked for are never touched;
+otherwise their sizes have to be read to find the tiles that follow, as
+`oapvd_decode_frame()` does.
+
+There is no `oapvd_stat_t` argument. The frame's own information is already
+available from `oapvd_info_frame()` and `oapvd_info_tile()` on the same PBU,
+which an application has called to plan the selection.
+
 ### Zero-copy decoding input with memory-mapped files
 
 The decoder never writes to the bitstream buffer: `oapv_bitb_t.addr` is

--- a/src/oapv.c
+++ b/src/oapv.c
@@ -1990,6 +1990,26 @@ static int dec_tiles_prepare(oapvd_ctx_t *ctx, int num_tiles, oapv_tile_req_t *t
     ret = dec_frm_setup(ctx, tile_reqs[0].imgb.cs);
     oapv_assert_rv(OAPV_SUCCEEDED(ret), ret);
 
+    // the tile sizes of the frame header land here, so the buffer follows the
+    // tile array: same count, grown the same way, and only for the frames that
+    // carry the sizes at all
+    if(ctx->fh.tile_size_present_in_fh_flag && ctx->num_tiles > ctx->pos_tiles_cap) {
+        // the allocator takes a 32-bit size, so reject a request that would not
+        // survive the conversion instead of letting it truncate
+        s64 pos_bytes = (s64)sizeof(oapv_tile_pos_t) * ctx->num_tiles;
+        oapv_assert_rv(pos_bytes <= (s64)UINT_MAX, OAPV_ERR_MALFORMED_BITSTREAM);
+
+        oapv_ops_free(ctx, ctx->pos_tiles);
+        // clear both, so a failed allocation cannot leave a stale capacity
+        // beside a pointer that is no longer valid
+        ctx->pos_tiles = NULL;
+        ctx->pos_tiles_cap = 0;
+
+        ctx->pos_tiles = (oapv_tile_pos_t *)oapv_ops_malloc(ctx, (unsigned int)pos_bytes);
+        oapv_assert_rv(ctx->pos_tiles != NULL, OAPV_ERR_OUT_OF_MEMORY);
+        ctx->pos_tiles_cap = ctx->num_tiles;
+    }
+
     for(i = 0; i < num_tiles; i++) {
         const oapv_imgb_tile_t *dst = &tile_reqs[i].imgb;
         int                     idx = tile_reqs[i].idx;
@@ -2108,6 +2128,10 @@ static void dec_flush(oapvd_ctx_t *ctx)
     oapv_ops_free(ctx, ctx->tile);
     ctx->tile = NULL;
     ctx->tile_cap = 0;
+
+    oapv_ops_free(ctx, ctx->pos_tiles);
+    ctx->pos_tiles = NULL;
+    ctx->pos_tiles_cap = 0;
 }
 
 static int dec_ready(oapvd_ctx_t *ctx)
@@ -2697,6 +2721,7 @@ int oapvd_decode_tiles(oapvd_t did, oapv_bitb_t *bitb, int num_tiles, oapv_tile_
     oapv_pbuh_t      pbuh;
     oapv_tile_pos_t *pos_tiles = NULL;
     u8              *fh_beg;
+    int              pos_tiles_cap;
     int              ret = OAPV_OK;
 
     ctx = dec_id_to_ctx(did);
@@ -2716,33 +2741,34 @@ int oapvd_decode_tiles(oapvd_t did, oapv_bitb_t *bitb, int num_tiles, oapv_tile_
     // check frame type PBU
     oapv_assert_rv(OAPV_PBU_TYPE_IS_FRAME(pbuh.pbu_type), OAPV_ERR_INVALID_ARGUMENT);
 
-    // parse frame header
+    // parse frame header. tile sizes in it locate every tile without reading a
+    // byte of any tile, which is what keeps a selective decode off the pages it
+    // does not need, so they are collected as the header is read - whenever the
+    // buffer a previous frame left behind is already large enough to take them.
     fh_beg = (u8 *)oapv_bsr_sink(&ctx->bs);
-    ret = oapvd_vlc_frame_header(&ctx->bs, &ctx->fh, NULL, 0);
+    pos_tiles_cap = ctx->pos_tiles_cap;
+    ret = oapvd_vlc_frame_header(&ctx->bs, &ctx->fh, ctx->pos_tiles, pos_tiles_cap);
     oapv_assert_rv(OAPV_SUCCEEDED(ret), ret);
 
     ret = dec_tiles_prepare(ctx, num_tiles, tile_reqs);
     oapv_assert_rv(OAPV_SUCCEEDED(ret), ret);
 
-    // tile sizes in the frame header locate every tile without reading a byte of
-    // any tile, which is what keeps a selective decode off the pages it does not
-    // need. they are worth a second pass over the header to collect.
     if(ctx->fh.tile_size_present_in_fh_flag) {
-        oapv_bs_t bs;
-        oapv_fh_t fh;
-        s64       pos_bytes = (s64)sizeof(oapv_tile_pos_t) * ctx->num_tiles;
+        pos_tiles = ctx->pos_tiles;
+        if(pos_tiles_cap < ctx->num_tiles) {
+            // the buffer had to grow for this frame, so the pass above had
+            // nowhere to put the sizes; read the header again to collect them
+            oapv_bs_t bs;
+            oapv_fh_t fh;
 
-        oapv_assert_gv(pos_bytes <= (s64)UINT_MAX, ret, OAPV_ERR_MALFORMED_BITSTREAM, ERR);
-        pos_tiles = (oapv_tile_pos_t *)oapv_ops_malloc(ctx, (unsigned int)pos_bytes);
-        oapv_assert_gv(pos_tiles != NULL, ret, OAPV_ERR_OUT_OF_MEMORY, ERR);
-
-        oapv_bsr_init(&bs, fh_beg, (u32)(ctx->bs.end - fh_beg), NULL);
-        ret = oapvd_vlc_frame_header(&bs, &fh, pos_tiles, ctx->num_tiles);
-        oapv_assert_g(OAPV_SUCCEEDED(ret), ERR);
+            oapv_bsr_init(&bs, fh_beg, (u32)(ctx->bs.end - fh_beg), NULL);
+            ret = oapvd_vlc_frame_header(&bs, &fh, pos_tiles, ctx->num_tiles);
+            oapv_assert_rv(OAPV_SUCCEEDED(ret), ret);
+        }
     }
 
     ret = dec_derive_tile_offsets(ctx, pos_tiles);
-    oapv_assert_g(OAPV_SUCCEEDED(ret), ERR);
+    oapv_assert_rv(OAPV_SUCCEEDED(ret), ret);
 
     int           thread_ret;
     oapv_tpool_t *tpool = ctx->tpool;
@@ -2763,8 +2789,6 @@ int oapvd_decode_tiles(oapvd_t did, oapv_bitb_t *bitb, int num_tiles, oapv_tile_
     }
     /****************************************************/
 
-ERR:
-    oapv_ops_free(ctx, pos_tiles);
     return ret;
 }
 

--- a/src/oapv.c
+++ b/src/oapv.c
@@ -1990,10 +1990,6 @@ static int dec_tiles_prepare(oapvd_ctx_t *ctx, int num_tiles, oapv_tile_req_t *t
     ret = dec_frm_setup(ctx, tile_reqs[0].imgb.cs);
     oapv_assert_rv(OAPV_SUCCEEDED(ret), ret);
 
-    for(i = 0; i < ctx->num_tiles; i++) {
-        ctx->tile[i].stat = DEC_TILE_STAT_DO(DEC_TILE_STAT_SKIP); /* bypass decoding */
-    }
-
     for(i = 0; i < num_tiles; i++) {
         const oapv_imgb_tile_t *dst = &tile_reqs[i].imgb;
         int                     idx = tile_reqs[i].idx;
@@ -2008,7 +2004,6 @@ static int dec_tiles_prepare(oapvd_ctx_t *ctx, int num_tiles, oapv_tile_req_t *t
         oapv_assert_rv(OAPV_SUCCEEDED(ret), ret);
 
         ctx->tile[idx].dst = dst;
-        ctx->tile[idx].stat = DEC_TILE_STAT_DO(DEC_TILE_STAT_DECODE);
     }
 
     return OAPV_OK;
@@ -2067,7 +2062,6 @@ static int dec_thread_tile_sel(void *arg)
         }
         tidx = ctx->tile_idx;
         if(tidx < ctx->num_tiles) {
-            tile[tidx].stat = DEC_TILE_STAT_ON(tile[tidx].stat);
             ++ctx->tile_idx;
         }
         oapv_tpool_leave_cs(ctx->sync_obj);
@@ -2076,16 +2070,9 @@ static int dec_thread_tile_sel(void *arg)
         }
 
         ret = dec_tile(core, &tile[tidx]);
-
-        oapv_tpool_enter_cs(ctx->sync_obj);
-        if(OAPV_SUCCEEDED(ret)) {
-            tile[tidx].stat = DEC_TILE_STAT_DONE(tile[tidx].stat);
-        }
-        else {
-            tile[tidx].stat = DEC_TILE_STAT_ERR(tile[tidx].stat);
+        if(OAPV_FAILED(ret)) {
             thread_ret = ret;
         }
-        oapv_tpool_leave_cs(ctx->sync_obj);
     }
 
     return thread_ret;

--- a/src/oapv.c
+++ b/src/oapv.c
@@ -1596,48 +1596,18 @@ static int dec_set_tile_info(oapvd_tile_t* tile, int w_pel, int h_pel, int tile_
     return OAPV_OK;
 }
 
-static int dec_frm_prepare(oapvd_ctx_t *ctx, int num_part_tiles, const int *part_tile_idxs, oapv_imgb_t *imgb)
+static int dec_frm_setup(oapvd_ctx_t *ctx, int cs)
 {
     int i, ret;
 
-    oapv_assert_rv(imgb != NULL, OAPV_ERR_MALFORMED_BITSTREAM);
-
-    // the input image buffer must match the frame format signaled in the
-    // bitstream; a mismatch (e.g. caused by a resolution change without
-    // reallocation) is rejected as an invalid argument
-    if (imgb->w[0] != ctx->fh.fi.frame_width || imgb->h[0] != ctx->fh.fi.frame_height) {
-        return OAPV_ERR_INVALID_ARGUMENT;
-    }
-    // the color space of the input buffer must correspond to the bitstream's
-    // chroma format (note: OAPV_CF_PLANAR2 maps to chroma_format_idc 2 so the
+    // the color space of the output must correspond to the bitstream's chroma
+    // format (note: OAPV_CF_PLANAR2 maps to chroma_format_idc 2 so the
     // YCbCr422 -> P210 output path is accepted)
-    if (color_format_to_chroma_format_idc(OAPV_CS_GET_FORMAT(imgb->cs)) != ctx->fh.fi.chroma_format_idc) {
+    if(color_format_to_chroma_format_idc(OAPV_CS_GET_FORMAT(cs)) != ctx->fh.fi.chroma_format_idc) {
         return OAPV_ERR_INVALID_ARGUMENT;
     }
 
-    // validate buffer capacity for each component
-    // calculate required buffer size based on frame header information
-    int aligned_w = oapv_align_value(ctx->fh.fi.frame_width, OAPV_MB_W);
-    int aligned_h = oapv_align_value(ctx->fh.fi.frame_height, OAPV_MB_H);
-    int byte_depth = (ctx->fh.fi.bit_depth + 7) / 8; // bytes per pixel
-
-    for(int c = 0; c < imgb->np; c++) {
-        int comp_w = aligned_w >> (c > 0 ? get_chroma_sft_w(ctx->fh.fi.chroma_format_idc) : 0);
-        int comp_h = aligned_h >> (c > 0 ? get_chroma_sft_h(ctx->fh.fi.chroma_format_idc) : 0);
-        // frame_width/height are signaled in 24 bits, so the required buffer
-        // size can exceed INT_MAX; compute in s64 so the product does not wrap
-        // and let a too-small (int) bsize incorrectly pass the check
-        int required_stride = comp_w * byte_depth;
-        s64 required_bsize = (s64)required_stride * comp_h;
-
-        if((s64)imgb->bsize[c] < required_bsize) {
-            return OAPV_ERR_INVALID_ARGUMENT;
-        }
-    }
-
-    ctx->imgb = imgb;
-    imgb_addref(ctx->imgb); // increase reference count
-
+    ctx->cs = cs;
     ctx->bit_depth = ctx->fh.fi.bit_depth;
     ctx->cfi = ctx->fh.fi.chroma_format_idc;
     ctx->num_c = get_num_comp(ctx->cfi);
@@ -1645,8 +1615,8 @@ static int dec_frm_prepare(oapvd_ctx_t *ctx, int num_part_tiles, const int *part
     ctx->c_sft[Y_C][1] = 0;
 
     for(int c = 1; c < ctx->num_c; c++) {
-        ctx->c_sft[c][0] = get_chroma_sft_w(color_format_to_chroma_format_idc(OAPV_CS_GET_FORMAT(imgb->cs)));
-        ctx->c_sft[c][1] = get_chroma_sft_h(color_format_to_chroma_format_idc(OAPV_CS_GET_FORMAT(imgb->cs)));
+        ctx->c_sft[c][0] = get_chroma_sft_w(color_format_to_chroma_format_idc(OAPV_CS_GET_FORMAT(cs)));
+        ctx->c_sft[c][1] = get_chroma_sft_h(color_format_to_chroma_format_idc(OAPV_CS_GET_FORMAT(cs)));
     }
 
     ctx->w = oapv_align_value(ctx->fh.fi.frame_width, OAPV_MB_W);
@@ -1657,7 +1627,7 @@ static int dec_frm_prepare(oapvd_ctx_t *ctx, int num_part_tiles, const int *part
         ctx->disable_companding = ctx->force_disable_companding;
     }
 
-    if(OAPV_CS_GET_FORMAT(imgb->cs) == OAPV_CF_PLANAR2) {
+    if(OAPV_CS_GET_FORMAT(cs) == OAPV_CF_PLANAR2) {
         ctx->fn_blk_to_pic[Y_C] = oapv_blk_to_pic_p21x_y;
         ctx->fn_blk_to_pic[U_C] = oapv_blk_to_pic_p21x_uv;
         ctx->fn_blk_to_pic[V_C] = oapv_blk_to_pic_p21x_uv;
@@ -1715,8 +1685,49 @@ static int dec_frm_prepare(oapvd_ctx_t *ctx, int num_part_tiles, const int *part
 
     for(i = 0; i < ctx->num_tiles; i++) {
         ctx->tile[i].bs_beg = NULL;
+        ctx->tile[i].dst = NULL;
     }
     ctx->tile[0].bs_beg = oapv_bsr_sink(&ctx->bs);
+    ctx->tile_idx = 0;
+
+    return OAPV_OK;
+}
+
+static int dec_frm_prepare(oapvd_ctx_t *ctx, int num_part_tiles, const int *part_tile_idxs, oapv_imgb_t *imgb)
+{
+    int i, ret;
+
+    oapv_assert_rv(imgb != NULL, OAPV_ERR_MALFORMED_BITSTREAM);
+
+    // the input image buffer must match the frame format signaled in the
+    // bitstream; a mismatch (e.g. caused by a resolution change without
+    // reallocation) is rejected as an invalid argument
+    if (imgb->w[0] != ctx->fh.fi.frame_width || imgb->h[0] != ctx->fh.fi.frame_height) {
+        return OAPV_ERR_INVALID_ARGUMENT;
+    }
+
+    ret = dec_frm_setup(ctx, imgb->cs);
+    oapv_assert_rv(OAPV_SUCCEEDED(ret), ret);
+
+    // validate buffer capacity for each component
+    int byte_depth = (ctx->fh.fi.bit_depth + 7) / 8; // bytes per pixel
+
+    for(int c = 0; c < imgb->np; c++) {
+        int comp_w = ctx->w >> (c > 0 ? get_chroma_sft_w(ctx->cfi) : 0);
+        int comp_h = ctx->h >> (c > 0 ? get_chroma_sft_h(ctx->cfi) : 0);
+        // frame_width/height are signaled in 24 bits, so the required buffer
+        // size can exceed INT_MAX; compute in s64 so the product does not wrap
+        // and let a too-small (int) bsize incorrectly pass the check
+        int required_stride = comp_w * byte_depth;
+        s64 required_bsize = (s64)required_stride * comp_h;
+
+        if((s64)imgb->bsize[c] < required_bsize) {
+            return OAPV_ERR_INVALID_ARGUMENT;
+        }
+    }
+
+    ctx->imgb = imgb;
+    imgb_addref(ctx->imgb); // increase reference count
 
     if(num_part_tiles > 0) {
         oapv_assert_rv(part_tile_idxs != NULL, OAPV_ERR_INVALID_ARGUMENT);
@@ -1744,7 +1755,7 @@ static void dec_frm_finish(oapvd_ctx_t *ctx)
     ctx->imgb = NULL;
 }
 
-static int dec_tile_comp(oapvd_tile_t *tile, oapvd_ctx_t *ctx, oapvd_core_t *core, oapv_bs_t *bs, int c, int pic_s, void *pic)
+static int dec_tile_comp(oapvd_tile_t *tile, oapvd_ctx_t *ctx, oapvd_core_t *core, oapv_bs_t *bs, int c, int pic_s, void *pic, int tile_local)
 {
     int  mb_h, mb_w, y, x, j, i;
     int  le, ri, to, bo;
@@ -1758,6 +1769,11 @@ static int dec_tile_comp(oapvd_tile_t *tile, oapvd_ctx_t *ctx, oapvd_core_t *cor
     ri = (tile->w >> ctx->c_sft[c][0]) + le; // right pixel position of tile
     to = tile->y >> ctx->c_sft[c][1];        // top pixel position of tile
     bo = (tile->h >> ctx->c_sft[c][1]) + to; // bottom pixel position of tile
+
+    // a destination of its own puts the tile's top-left corner at its origin,
+    // whereas a full-frame buffer is addressed in picture coordinates
+    int org_x = tile_local ? le : 0;
+    int org_y = tile_local ? to : 0;
 
     for(y = to; y < bo; y += mb_h) {
         for(x = le; x < ri; x += mb_w) {
@@ -1780,8 +1796,9 @@ static int dec_tile_comp(oapvd_tile_t *tile, oapvd_ctx_t *ctx, oapvd_core_t *cor
                     oapv_assert_rv(OAPV_SUCCEEDED(ret), ret);
 
                     // copy decoded block to image buffer
-                    pic_t = (s16 *)((u8 *)pic + j * pic_s) + i;
-                    ctx->fn_blk_to_pic[c](OAPV_BLK_W, OAPV_BLK_H, core->coef, (OAPV_BLK_W << 1), pic_t, i, pic_s, ctx->bit_depth);
+                    int dst_x = i - org_x;
+                    pic_t = (s16 *)((u8 *)pic + (j - org_y) * pic_s) + dst_x;
+                    ctx->fn_blk_to_pic[c](OAPV_BLK_W, OAPV_BLK_H, core->coef, (OAPV_BLK_W << 1), pic_t, dst_x, pic_s, ctx->bit_depth);
                 }
             }
         }
@@ -1826,21 +1843,32 @@ static int dec_tile(oapvd_core_t *core, oapvd_tile_t *tile)
         int  tc, pic_s;
         s16 *pic;
         oapv_bs_t bsc; // bs for 'tile_data()' syntax
+        void *const *dst_a;
+        const int   *dst_s;
 
         oapv_bsr_init(&bsc, BSR_GET_CUR(&bs), tile->th.tile_data_size[c], NULL);
 
-        if(OAPV_CS_GET_FORMAT(ctx->imgb->cs) == OAPV_CF_PLANAR2) {
-            tc = c > 0 ? 1 : 0;
-            pic = ctx->imgb->a[tc];
-            pic += (c > 1) ? 1 : 0;
-            pic_s = ctx->imgb->s[tc];
+        if(tile->dst != NULL) {
+            dst_a = tile->dst->a;
+            dst_s = tile->dst->s;
         }
         else {
-            pic = ctx->imgb->a[c];
-            pic_s = ctx->imgb->s[c];
+            dst_a = ctx->imgb->a;
+            dst_s = ctx->imgb->s;
         }
 
-        ret = dec_tile_comp(tile, ctx, core, &bsc, c, pic_s, pic);
+        if(OAPV_CS_GET_FORMAT(ctx->cs) == OAPV_CF_PLANAR2) {
+            tc = c > 0 ? 1 : 0;
+            pic = dst_a[tc];
+            pic += (c > 1) ? 1 : 0;
+            pic_s = dst_s[tc];
+        }
+        else {
+            pic = dst_a[c];
+            pic_s = dst_s[c];
+        }
+
+        ret = dec_tile_comp(tile, ctx, core, &bsc, c, pic_s, pic, tile->dst != NULL);
         oapv_assert_rv(OAPV_SUCCEEDED(ret), ret);
 
         // move bs buffer to next 'tile_data()' component
@@ -1926,6 +1954,141 @@ ERR:
     }
     oapv_tpool_leave_cs(ctx->sync_obj);
     return OAPV_ERR_MALFORMED_BITSTREAM;
+}
+
+/* a destination holds one sample per pixel, so a component of the tile needs
+   (rows - 1) * stride + row bytes behind its address; interleaved chroma keeps
+   U and V in the same row of the same plane. */
+static int dec_tile_dst_check(oapvd_ctx_t *ctx, const oapvd_tile_t *tile, const oapv_imgb_tile_t *dst)
+{
+    int planar2 = (OAPV_CS_GET_FORMAT(ctx->cs) == OAPV_CF_PLANAR2);
+    int num_pln = planar2 ? 2 : ctx->num_c;
+    int byte_depth = (ctx->bit_depth + 7) / 8;
+
+    for(int p = 0; p < num_pln; p++) {
+        int c = (planar2 && p > 0) ? U_C : p; // the component stored in this plane
+        int w = tile->w >> ctx->c_sft[c][0];
+        int h = tile->h >> ctx->c_sft[c][1];
+        s64 row = (s64)w * byte_depth * ((planar2 && p > 0) ? 2 : 1);
+
+        if(dst->a[p] == NULL || (s64)dst->s[p] < row) {
+            return OAPV_ERR_INVALID_ARGUMENT;
+        }
+        // the capacity is optional, as oapv_bitb_t's is
+        if(dst->bsize[p] > 0 && (s64)dst->bsize[p] < (s64)dst->s[p] * (h - 1) + row) {
+            return OAPV_ERR_INVALID_ARGUMENT;
+        }
+    }
+
+    return OAPV_OK;
+}
+
+static int dec_tiles_prepare(oapvd_ctx_t *ctx, int num_tiles, oapv_tile_req_t *tile_reqs)
+{
+    int i, ret;
+
+    ret = dec_frm_setup(ctx, tile_reqs[0].imgb.cs);
+    oapv_assert_rv(OAPV_SUCCEEDED(ret), ret);
+
+    for(i = 0; i < ctx->num_tiles; i++) {
+        ctx->tile[i].stat = DEC_TILE_STAT_DO(DEC_TILE_STAT_SKIP); /* bypass decoding */
+    }
+
+    for(i = 0; i < num_tiles; i++) {
+        const oapv_imgb_tile_t *dst = &tile_reqs[i].imgb;
+        int                     idx = tile_reqs[i].idx;
+
+        oapv_assert_rv(idx >= 0 && idx < ctx->num_tiles, OAPV_ERR_INVALID_ARGUMENT);
+        // one layout for the whole call; dec_frm_setup() has checked it against
+        // the bitstream's chroma format already
+        oapv_assert_rv(dst->cs == ctx->cs, OAPV_ERR_INVALID_ARGUMENT);
+        oapv_assert_rv(ctx->tile[idx].dst == NULL, OAPV_ERR_INVALID_ARGUMENT);
+
+        ret = dec_tile_dst_check(ctx, &ctx->tile[idx], dst);
+        oapv_assert_rv(OAPV_SUCCEEDED(ret), ret);
+
+        ctx->tile[idx].dst = dst;
+        ctx->tile[idx].stat = DEC_TILE_STAT_DO(DEC_TILE_STAT_DECODE);
+    }
+
+    return OAPV_OK;
+}
+
+/* the start and the size of every tile, so that a selective decode can go
+   straight to the tiles it wants. the frame header carries the sizes when
+   tile_size_present_in_fh_flag is set; without them each size has to be read
+   from the head of the tile before it, walking the frame from the front the way
+   oapvd_decode_frame() does. */
+static int dec_derive_tile_offsets(oapvd_ctx_t *ctx, const oapv_tile_pos_t *pos_tiles)
+{
+    oapv_bs_t bs;
+    u8       *beg = ctx->tile[0].bs_beg;
+    int       ret;
+
+    for(int i = 0; i < ctx->num_tiles; i++) {
+        // the remaining bytes bound the tile, and comparing against them keeps
+        // a crafted size from carrying the position past the end of the buffer
+        s64 remain = (s64)(ctx->bs.end - beg);
+        oapv_assert_rv(remain >= OAPV_TILE_SIZE_LEN, OAPV_ERR_MALFORMED_BITSTREAM);
+
+        if(pos_tiles != NULL) {
+            ctx->tile[i].tile_size = (u32)pos_tiles[i].size;
+        }
+        else {
+            oapv_bsr_init(&bs, beg, OAPV_TILE_SIZE_LEN, NULL);
+            ret = oapvd_vlc_tile_size(&bs, &ctx->tile[i].tile_size);
+            oapv_assert_rv(OAPV_SUCCEEDED(ret), ret);
+        }
+        oapv_assert_rv((s64)ctx->tile[i].tile_size <= remain - OAPV_TILE_SIZE_LEN, OAPV_ERR_MALFORMED_BITSTREAM);
+
+        ctx->tile[i].bs_beg = beg;
+        beg += OAPV_TILE_SIZE_LEN + ctx->tile[i].tile_size;
+    }
+    ctx->tile_end = beg;
+
+    return OAPV_OK;
+}
+
+/* the tiles a selective decode asked for, taken in ascending index order. tile
+   data is laid out in that order, so the bitstream is read front to back rather
+   than jumped back and forth in. */
+static int dec_thread_tile_sel(void *arg)
+{
+    int           tidx, ret, thread_ret = OAPV_OK;
+
+    oapvd_core_t *core = (oapvd_core_t *)arg;
+    oapvd_ctx_t  *ctx = core->ctx;
+    oapvd_tile_t *tile = ctx->tile;
+
+    while(1) {
+        oapv_tpool_enter_cs(ctx->sync_obj);
+        while(ctx->tile_idx < ctx->num_tiles && tile[ctx->tile_idx].dst == NULL) {
+            ++ctx->tile_idx;
+        }
+        tidx = ctx->tile_idx;
+        if(tidx < ctx->num_tiles) {
+            tile[tidx].stat = DEC_TILE_STAT_ON(tile[tidx].stat);
+            ++ctx->tile_idx;
+        }
+        oapv_tpool_leave_cs(ctx->sync_obj);
+        if(tidx >= ctx->num_tiles) {
+            break; // end of worker thread
+        }
+
+        ret = dec_tile(core, &tile[tidx]);
+
+        oapv_tpool_enter_cs(ctx->sync_obj);
+        if(OAPV_SUCCEEDED(ret)) {
+            tile[tidx].stat = DEC_TILE_STAT_DONE(tile[tidx].stat);
+        }
+        else {
+            tile[tidx].stat = DEC_TILE_STAT_ERR(tile[tidx].stat);
+            thread_ret = ret;
+        }
+        oapv_tpool_leave_cs(ctx->sync_obj);
+    }
+
+    return thread_ret;
 }
 
 static void dec_flush(oapvd_ctx_t *ctx)
@@ -2152,7 +2315,7 @@ int oapvd_decode(oapvd_t did, oapv_bitb_t *bitb, oapv_frms_t *ofrms, oapvm_t mid
 
             oapv_assert_gv(nfrms < OAPV_MAX_NUM_FRAMES, ret, OAPV_ERR_REACHED_MAX, ERR);
 
-            ret = oapvd_vlc_frame_header(bs, &ctx->fh);
+            ret = oapvd_vlc_frame_header(bs, &ctx->fh, NULL, 0);
             oapv_assert_g(OAPV_SUCCEEDED(ret), ERR);
 
             ret = dec_frm_prepare(ctx, 0, NULL, ofrms->frm[nfrms].imgb);
@@ -2300,7 +2463,7 @@ int oapvd_info(void *au, int au_size, oapv_au_info_t *aui)
             oapv_fh_t fh;
 
             oapv_assert_rv(frm_count < OAPV_MAX_NUM_FRAMES, OAPV_ERR_REACHED_MAX)
-            ret = oapvd_vlc_frame_header(&bs, &fh);
+            ret = oapvd_vlc_frame_header(&bs, &fh, NULL, 0);
             oapv_assert_rv(OAPV_SUCCEEDED(ret), ret);
 
             fh_to_finfo(&fh, pbuh.pbu_type, pbuh.group_id, &aui->frm_info[frm_count]);
@@ -2347,7 +2510,7 @@ int oapvd_info_frame(void *pbu, int pbu_size, oapv_frm_info_t *frm_info)
     oapv_assert_gv(OAPV_PBU_TYPE_IS_FRAME(pbuh.pbu_type), ret, OAPV_ERR_INVALID_ARGUMENT, ERR);
 
     // decode frame header
-    ret = oapvd_vlc_frame_header(&bs, &fh);
+    ret = oapvd_vlc_frame_header(&bs, &fh, NULL, 0);
     oapv_assert_g(OAPV_SUCCEEDED(ret), ERR);
 
     fh_to_finfo(&fh, pbuh.pbu_type, pbuh.group_id, frm_info);
@@ -2386,7 +2549,7 @@ int oapvd_info_tile(void *pbu, int pbu_size, oapv_tile_pos_t *pos_tiles, int *nu
             pos_tiles[i].size = 0;
         }
     }
-    ret = oapvd_vlc_frame_header_ex(&bs, &fh, pos_tiles, (pos_tiles != NULL) ? *num_tiles : 0);
+    ret = oapvd_vlc_frame_header(&bs, &fh, pos_tiles, (pos_tiles != NULL) ? *num_tiles : 0);
     oapv_assert_g(OAPV_SUCCEEDED(ret), ERR);
 
     pic_w_mb = (fh.fi.frame_width + (OAPV_MB_W - 1)) >> OAPV_LOG2_MB_W;
@@ -2479,7 +2642,7 @@ int oapvd_decode_frame(oapvd_t did, oapv_bitb_t *bitb, oapv_imgb_t *imgb, oapvd_
     oapv_assert_gv(OAPV_PBU_TYPE_IS_FRAME(pbuh.pbu_type), ret, OAPV_ERR_INVALID_ARGUMENT, ERR);
 
     // parse frame header
-    ret = oapvd_vlc_frame_header(bs, &ctx->fh);
+    ret = oapvd_vlc_frame_header(bs, &ctx->fh, NULL, 0);
     oapv_assert_g(OAPV_SUCCEEDED(ret), ERR);
 
     // be ready to decode start
@@ -2540,6 +2703,83 @@ ERR:
     return ret;
 
     return OAPV_OK;
+}
+
+int oapvd_decode_tiles(oapvd_t did, oapv_bitb_t *bitb, int num_tiles, oapv_tile_req_t *tile_reqs)
+{
+    oapvd_ctx_t     *ctx;
+    oapv_pbuh_t      pbuh;
+    oapv_tile_pos_t *pos_tiles = NULL;
+    u8              *fh_beg;
+    int              ret = OAPV_OK;
+
+    ctx = dec_id_to_ctx(did);
+    oapv_assert_rv(ctx, OAPV_ERR_INVALID_ARGUMENT);
+    oapv_assert_rv(bitb != NULL && bitb->addr != NULL, OAPV_ERR_INVALID_ARGUMENT);
+    oapv_assert_rv(num_tiles > 0 && tile_reqs != NULL, OAPV_ERR_INVALID_ARGUMENT);
+
+    oapv_assert_rv(bitb->ssize >= 8, OAPV_ERR_MALFORMED_BITSTREAM);
+    if(bitb->bsize > 0) {
+        oapv_assert_rv(bitb->ssize <= bitb->bsize, OAPV_ERR_INVALID_ARGUMENT);
+    }
+    oapv_bsr_init(&ctx->bs, (u8 *)bitb->addr, bitb->ssize, NULL);
+
+    // parse PBU header
+    ret = oapvd_vlc_pbu_header(&ctx->bs, &pbuh);
+    oapv_assert_rv(OAPV_SUCCEEDED(ret), ret);
+    // check frame type PBU
+    oapv_assert_rv(OAPV_PBU_TYPE_IS_FRAME(pbuh.pbu_type), OAPV_ERR_INVALID_ARGUMENT);
+
+    // parse frame header
+    fh_beg = (u8 *)oapv_bsr_sink(&ctx->bs);
+    ret = oapvd_vlc_frame_header(&ctx->bs, &ctx->fh, NULL, 0);
+    oapv_assert_rv(OAPV_SUCCEEDED(ret), ret);
+
+    ret = dec_tiles_prepare(ctx, num_tiles, tile_reqs);
+    oapv_assert_rv(OAPV_SUCCEEDED(ret), ret);
+
+    // tile sizes in the frame header locate every tile without reading a byte of
+    // any tile, which is what keeps a selective decode off the pages it does not
+    // need. they are worth a second pass over the header to collect.
+    if(ctx->fh.tile_size_present_in_fh_flag) {
+        oapv_bs_t bs;
+        oapv_fh_t fh;
+        s64       pos_bytes = (s64)sizeof(oapv_tile_pos_t) * ctx->num_tiles;
+
+        oapv_assert_gv(pos_bytes <= (s64)UINT_MAX, ret, OAPV_ERR_MALFORMED_BITSTREAM, ERR);
+        pos_tiles = (oapv_tile_pos_t *)oapv_ops_malloc(ctx, (unsigned int)pos_bytes);
+        oapv_assert_gv(pos_tiles != NULL, ret, OAPV_ERR_OUT_OF_MEMORY, ERR);
+
+        oapv_bsr_init(&bs, fh_beg, (u32)(ctx->bs.end - fh_beg), NULL);
+        ret = oapvd_vlc_frame_header(&bs, &fh, pos_tiles, ctx->num_tiles);
+        oapv_assert_g(OAPV_SUCCEEDED(ret), ERR);
+    }
+
+    ret = dec_derive_tile_offsets(ctx, pos_tiles);
+    oapv_assert_g(OAPV_SUCCEEDED(ret), ERR);
+
+    int           thread_ret;
+    oapv_tpool_t *tpool = ctx->tpool;
+    int           parallel_task = (ctx->threads > num_tiles) ? num_tiles : ctx->threads;
+    int           tidx = 0;
+
+    /* decode tiles ************************************/
+    for(tidx = 0; tidx < (parallel_task - 1); tidx++) {
+        tpool->run(ctx->thread_id[tidx], dec_thread_tile_sel,
+                   (void *)ctx->core[tidx]);
+    }
+    ret = dec_thread_tile_sel((void *)ctx->core[tidx]);
+    for(tidx = 0; tidx < parallel_task - 1; tidx++) {
+        tpool->join(ctx->thread_id[tidx], &thread_ret);
+        if(OAPV_FAILED(thread_ret)) {
+            ret = thread_ret;
+        }
+    }
+    /****************************************************/
+
+ERR:
+    oapv_ops_free(ctx, pos_tiles);
+    return ret;
 }
 
 int oapvd_decode_auinfo(oapvd_t did, oapv_bitb_t *bitb, oapv_au_info_t *aui)

--- a/src/oapv_def.h
+++ b/src/oapv_def.h
@@ -381,6 +381,10 @@ struct oapvd_tile {
     u8          *bs_beg;    /* start position of tile in input bistream */
     u8          *bs_end;    /* end position of tile() in input bistream */
     volatile s32 stat;      /* decoding status */
+
+    /* destination of this tile, or NULL when the tile is decoded into the
+       full-frame image buffer of the context */
+    const oapv_imgb_tile_t *dst;
 };
 
 typedef struct oapvd_core oapvd_core_t;
@@ -426,6 +430,7 @@ struct oapvd_ctx {
     int                     w;
     int                     h;
     int                     threads;
+    int                     cs;            // color space of the output
     int                     cfi;           // chroma format indicator
     int                     bit_depth;     // bit depth of decoding picture
     int                     num_c;         // number of components

--- a/src/oapv_def.h
+++ b/src/oapv_def.h
@@ -444,6 +444,9 @@ struct oapvd_ctx {
 
     oapv_fn_blk_to_pic_t   fn_blk_to_pic[N_C];
 
+    oapv_tile_pos_t        *pos_tiles;     // per-tile sizes of the frame header, allocated on demand
+    int                     pos_tiles_cap; // number of allocated pos_tiles entries
+
     /* platform specific data, if needed */
     void                   *pf;
 };

--- a/src/oapv_vlc.c
+++ b/src/oapv_vlc.c
@@ -1115,12 +1115,7 @@ int oapvd_vlc_au_info(oapv_bs_t *bs, oapv_aui_t *aui)
     return OAPV_OK;
 }
 
-int oapvd_vlc_frame_header(oapv_bs_t *bs, oapv_fh_t *fh)
-{
-    return oapvd_vlc_frame_header_ex(bs, fh, NULL, 0);
-}
-
-int oapvd_vlc_frame_header_ex(oapv_bs_t *bs, oapv_fh_t *fh, oapv_tile_pos_t *pos_tiles, int cap)
+int oapvd_vlc_frame_header(oapv_bs_t *bs, oapv_fh_t *fh, oapv_tile_pos_t *pos_tiles, int cap)
 {
     int ret, reserved_zero;
     ret = oapvd_vlc_frame_info(bs, &fh->fi);

--- a/src/oapv_vlc.h
+++ b/src/oapv_vlc.h
@@ -60,9 +60,9 @@ int  oapvd_vlc_pbu_size(oapv_bs_t* bs, u32 *pbu_size);
 int  oapvd_vlc_pbu_header(oapv_bs_t* bs, oapv_pbuh_t* pbuh);
 int  oapvd_vlc_au_info(oapv_bs_t* bs, oapv_aui_t* aui);
 
-int  oapvd_vlc_frame_header(oapv_bs_t* bs, oapv_fh_t* fh);
-/* variant reporting the per-tile sizes of the frame header, when present */
-int  oapvd_vlc_frame_header_ex(oapv_bs_t* bs, oapv_fh_t* fh, oapv_tile_pos_t* pos_tiles, int cap);
+/* 'pos_tiles' is optional: pass an array of at least 'cap' entries to have the
+   per-tile sizes of the frame header reported in it, or NULL to skip them */
+int  oapvd_vlc_frame_header(oapv_bs_t* bs, oapv_fh_t* fh, oapv_tile_pos_t* pos_tiles, int cap);
 int  oapvd_vlc_frame_info(oapv_bs_t* bs, oapv_fi_t *fi);
 int  oapvd_vlc_tile_size(oapv_bs_t *bs, u32 *tile_size);
 int  oapvd_vlc_tile_header(oapv_bs_t *bs, int num_comp, oapv_th_t *th, u32 tiles_data_size, int bit_depth);


### PR DESCRIPTION
Adds a decoder entry point that decodes a chosen set of tiles of one frame, each into a buffer of its own:

```c
OAPV_EXPORT int oapvd_decode_tiles(oapvd_t did, oapv_bitb_t *bitb, int num_tiles, oapv_tile_req_t *tile_reqs);
```

`bitb` carries a single frame PBU. Each `oapv_tile_req_t` names a tile and carries an `oapv_imgb_tile_t` destination — an address and a row stride per component — so the caller decides where each tile lands, whether that is a slot in an arena sized to its tile budget or the tile's own position in a full picture. `oapv_imgb_t` is unchanged.

Tile locations come from the frame header when `tile_size_present_in_fh_flag` is set, so unselected tiles are never read; without the sizes it walks forward, reading each tile's size to find the next. Requested tiles are decoded in ascending index order, which keeps the read moving forward through the bitstream. One frame per call.

Usage is documented in `readme/programmers_guide.md`.

This is the narrowed form of the capability proposed in #269, expressed in frame terms rather than mip levels.
