### PR TITLE
Remove the tile subset arguments from oapvd_decode_frame()

### DIFF
--- a/app/oapv_app_dec.c
+++ b/app/oapv_app_dec.c
@@ -806,7 +806,7 @@ int dec_api_set_1(args_var_t *args_var, FILE *fp_bs, int is_y4m)
     oapv_bitb_t       bitb;
     oapv_tile_req_t  *tile_reqs = NULL;
     int               tile_req_cap = 0;
-    int               num_part_tiles = 0;
+    int               num_dec_tiles = 0;
 
     oapv_imgb_t      *imgb_dec = NULL;
     oapv_imgb_t      *imgb_out = NULL;
@@ -976,20 +976,20 @@ int dec_api_set_1(args_var_t *args_var, FILE *fp_bs, int is_y4m)
                 }
 
                 if(args_var->cyclic_tile_decoding) {
-                    num_part_tiles = args_var->cyclic_tile_decoding;
-                    if(num_part_tiles > finfo.num_tiles) {
-                        num_part_tiles = finfo.num_tiles;
+                    num_dec_tiles = args_var->cyclic_tile_decoding;
+                    if(num_dec_tiles > finfo.num_tiles) {
+                        num_dec_tiles = finfo.num_tiles;
                     }
-                    if(tile_req_cap < num_part_tiles) {
+                    if(tile_req_cap < num_dec_tiles) {
                         free(tile_reqs);
-                        tile_reqs = malloc(sizeof(oapv_tile_req_t) * num_part_tiles);
+                        tile_reqs = malloc(sizeof(oapv_tile_req_t) * num_dec_tiles);
                         if(tile_reqs == NULL) {
                             logerr("ERR: cannot allocate tile request buffer\n");
                             ret = -1; goto ERR;
                         }
-                        tile_req_cap = num_part_tiles;
+                        tile_req_cap = num_dec_tiles;
                     }
-                    if(set_tile_reqs(tile_reqs, num_part_tiles, primary_frm_cnt, &finfo, imgb_dec)) {
+                    if(set_tile_reqs(tile_reqs, num_dec_tiles, primary_frm_cnt, &finfo, imgb_dec)) {
                         logerr("ERR: cannot address the tiles of the decoding buffer\n");
                         ret = -1; goto ERR;
                     }
@@ -1006,10 +1006,10 @@ int dec_api_set_1(args_var_t *args_var, FILE *fp_bs, int is_y4m)
                 clk_beg = oapv_clk_get();
 
                 if(args_var->cyclic_tile_decoding) {
-                    ret = oapvd_decode_tiles(did, &bitb, num_part_tiles, tile_reqs);
+                    ret = oapvd_decode_tiles(did, &bitb, num_dec_tiles, tile_reqs);
                 }
                 else {
-                    ret = oapvd_decode_frame(did, &bitb, imgb_dec, &stat, 0, NULL);
+                    ret = oapvd_decode_frame(did, &bitb, imgb_dec, &stat);
                 }
 
                 clk_end = oapv_clk_from(clk_beg);

--- a/inc/oapv.h
+++ b/inc/oapv.h
@@ -862,7 +862,7 @@ OAPV_EXPORT int oapvd_info_frame(void *pbu, int pbu_size, oapv_frm_info_t *frm_i
 OAPV_EXPORT int oapvd_info_tile(void *pbu, int pbu_size, oapv_tile_pos_t *pos_tiles, int *num_tiles);
 
 OAPV_EXPORT int oapvd_decode_auinfo(oapvd_t did, oapv_bitb_t *bitb, oapv_au_info_t *aui);
-OAPV_EXPORT int oapvd_decode_frame(oapvd_t did, oapv_bitb_t *bitb, oapv_imgb_t *imgb, oapvd_stat_t *stat, int num_part_tiles, const int *part_tile_idxs);
+OAPV_EXPORT int oapvd_decode_frame(oapvd_t did, oapv_bitb_t *bitb, oapv_imgb_t *imgb, oapvd_stat_t *stat);
 
 /*****************************************************************************
  * selective tile decoding
@@ -872,9 +872,9 @@ OAPV_EXPORT int oapvd_decode_frame(oapvd_t did, oapv_bitb_t *bitb, oapv_imgb_t *
  * does for oapvd_decode_frame(), and oapvd_info_tile() reports the tile indices
  * and dimensions needed to plan a selection.
  *
- * oapvd_decode_frame() also takes a tile subset, but decodes into a
- * scanline-strided oapv_imgb_t sized to the whole picture, so a partial decode
- * of a large frame still has to allocate that picture.
+ * oapvd_decode_frame() decodes every tile into a scanline-strided oapv_imgb_t
+ * sized to the whole picture, so decoding a few tiles of a large frame still
+ * has to allocate that picture.
  *****************************************************************************/
 
 /* destination of one decoded tile. unlike oapv_imgb_t this describes a tile and

--- a/readme/programmers_guide.md
+++ b/readme/programmers_guide.md
@@ -335,7 +335,7 @@ while(read_u32(input, &au_size) == OK) {
 
             bitb.addr = pbu_buf
             bitb.ssize = pbu_size
-            oapvd_decode_frame(did, &bitb, imgb, &stat, 0, NULL)  // all tiles
+            oapvd_decode_frame(did, &bitb, imgb, &stat)
 
             write_frame(output, imgb)
         }
@@ -347,35 +347,25 @@ while(read_u32(input, &au_size) == OK) {
 }
 ```
 
-### Tile-based partial decoding
+### Querying the tile layout
 
-With API set 1, `oapvd_decode_frame()` can decode only a subset of tiles.
-The tile layout of a frame is available from `oapvd_info_frame()` and
-`oapvd_info_tile()`:
+Decoding only some of the tiles of a frame starts from its tile layout,
+which is available from `oapvd_info_frame()` and `oapvd_info_tile()`:
 
 ```
 oapvd_info_frame(pbu_buf, pbu_size, &finfo)
 // finfo.num_tiles, finfo.tile_cols/tile_rows describe the tile grid
 
-// query the position of every tile, if needed
+// query the position of every tile
 pos = malloc(finfo.num_tiles * sizeof(oapv_tile_pos_t))
 num = finfo.num_tiles
 oapvd_info_tile(pbu_buf, pbu_size, pos, &num)
 
 // oapvd_info_tile() can report the count on its own as well, by passing a
 // NULL tile array:  num = 0; oapvd_info_tile(pbu_buf, pbu_size, NULL, &num)
-
-// select the tiles to decode, e.g. the ones covering a viewport
-part_tile_idxs = { 3, 4, 7, 8 }
-num_part_tiles = 4
-
-imgb = create_image_buffer(finfo.w, finfo.h, finfo.cs)
-oapvd_decode_frame(did, &bitb, imgb, &stat, num_part_tiles, part_tile_idxs)
-// only the selected tile regions of imgb are filled
 ```
 
-Passing `0, NULL` decodes every tile. The regions of unselected tiles are
-left untouched, so clear or reuse the image buffer accordingly.
+The selection itself is passed to `oapvd_decode_tiles()`, described below.
 
 When the frame header carries the tile sizes (the encoder writes them by
 default; see `OAPV_CFG_SET_TILE_SIZE_IN_FH`), `oapvd_info_tile()` also
@@ -423,10 +413,11 @@ as optional:
 
 ### Decoding tiles into buffers of their own
 
-`oapvd_decode_frame()` decodes a tile subset, but its output is one
-scanline-strided `oapv_imgb_t` sized to the whole picture, so a partial
-decode of a large frame still has to allocate that picture.
-`oapvd_decode_tiles()` gives each tile a destination of its own:
+`oapvd_decode_frame()` decodes a whole frame into one scanline-strided
+`oapv_imgb_t` sized to the picture, so an application that wants a few tiles
+of a large frame still has to allocate that picture.
+`oapvd_decode_tiles()` decodes a chosen set of tiles and gives each one a
+destination of its own:
 
 ```
 oapvd_decode_tiles(did, &bitb, num_tiles, tile_reqs)
@@ -478,8 +469,8 @@ Because each request carries its own addresses, the application decides
 where a tile lands. Pointing them into one arena gives an output sized to
 the number of tiles asked for rather than to the frame's tile count, which
 is what a viewport-driven client wants. Pointing them into a picture-sized
-buffer, at each tile's own position, reproduces what
-`oapvd_decode_frame()` does with `part_tile_idxs`.
+buffer, at each tile's own position, fills those tile regions of a frame and
+leaves the rest untouched.
 
 What the call requires:
 

--- a/src/oapv.c
+++ b/src/oapv.c
@@ -1737,7 +1737,7 @@ static int dec_frm_setup(oapvd_ctx_t *ctx, int cs)
     return OAPV_OK;
 }
 
-static int dec_frm_prepare(oapvd_ctx_t *ctx, int num_part_tiles, const int *part_tile_idxs, oapv_imgb_t *imgb)
+static int dec_frm_prepare(oapvd_ctx_t *ctx, oapv_imgb_t *imgb)
 {
     int i, ret;
 
@@ -1773,21 +1773,8 @@ static int dec_frm_prepare(oapvd_ctx_t *ctx, int num_part_tiles, const int *part
     ctx->imgb = imgb;
     imgb_addref(ctx->imgb); // increase reference count
 
-    if(num_part_tiles > 0) {
-        oapv_assert_rv(part_tile_idxs != NULL, OAPV_ERR_INVALID_ARGUMENT);
-        for(i = 0; i < ctx->num_tiles; i++) {
-            ctx->tile[i].stat = DEC_TILE_STAT_DO(DEC_TILE_STAT_SKIP); /* bypass decoding */
-        }
-        for(i = 0; i < num_part_tiles; i++) {
-            int idx = part_tile_idxs[i];
-            oapv_assert_rv(idx >= 0 && idx < ctx->num_tiles, OAPV_ERR_INVALID_ARGUMENT);
-            ctx->tile[idx].stat = DEC_TILE_STAT_DO(DEC_TILE_STAT_DECODE);
-        }
-    }
-    else {
-        for(i = 0; i < ctx->num_tiles; i++) {
-            ctx->tile[i].stat = DEC_TILE_STAT_DO(DEC_TILE_STAT_DECODE);
-        }
+    for(i = 0; i < ctx->num_tiles; i++) {
+        ctx->tile[i].stat = DEC_TILE_STAT_FLAG_DO;
     }
 
     return OAPV_OK;
@@ -1938,7 +1925,7 @@ static int dec_thread_tile(void *arg)
         tidx = ctx->tile_idx;
         if (ctx->tile_idx < ctx->num_tiles) {
             oapv_assert(DEC_TILE_STAT_IS_DO(tile[tidx].stat));
-            tile[tidx].stat = DEC_TILE_STAT_ON(tile[tidx].stat);
+            tile[tidx].stat = DEC_TILE_STAT_FLAG_ON;
             ++ctx->tile_idx;
         }
         oapv_tpool_leave_cs(ctx->sync_obj);
@@ -1973,16 +1960,14 @@ static int dec_thread_tile(void *arg)
         }
         oapv_tpool_leave_cs(ctx->sync_obj);
 
-        if(DEC_TILE_STAT_IS_DECODE(tile[tidx].stat)) {
-            ret = dec_tile(core, &tile[tidx]);
-        }
+        ret = dec_tile(core, &tile[tidx]);
 
         oapv_tpool_enter_cs(ctx->sync_obj);
         if (OAPV_SUCCEEDED(ret)) {
-            tile[tidx].stat = DEC_TILE_STAT_DONE(tile[tidx].stat);
+            tile[tidx].stat = DEC_TILE_STAT_FLAG_DONE;
         }
         else {
-            tile[tidx].stat = DEC_TILE_STAT_ERR(tile[tidx].stat);
+            tile[tidx].stat = DEC_TILE_STAT_FLAG_ERR;
             thread_ret = ret;
         }
         oapv_tpool_leave_cs(ctx->sync_obj);
@@ -1991,7 +1976,7 @@ static int dec_thread_tile(void *arg)
 
 ERR:
     oapv_tpool_enter_cs(ctx->sync_obj);
-    tile[tidx].stat = DEC_TILE_STAT_ERR(tile[tidx].stat);
+    tile[tidx].stat = DEC_TILE_STAT_FLAG_ERR;
     if (tidx + 1 < ctx->num_tiles)
     {
         tile[tidx + 1].bs_beg = tile[tidx].bs_beg;
@@ -2369,7 +2354,7 @@ int oapvd_decode(oapvd_t did, oapv_bitb_t *bitb, oapv_frms_t *ofrms, oapvm_t mid
             ret = oapvd_vlc_frame_header(bs, &ctx->fh, NULL, 0);
             oapv_assert_g(OAPV_SUCCEEDED(ret), ERR);
 
-            ret = dec_frm_prepare(ctx, 0, NULL, ofrms->frm[nfrms].imgb);
+            ret = dec_frm_prepare(ctx, ofrms->frm[nfrms].imgb);
             oapv_assert_g(OAPV_SUCCEEDED(ret), ERR);
 
             int           thread_ret;
@@ -2663,7 +2648,7 @@ ERR:
     return ret;
 }
 
-int oapvd_decode_frame(oapvd_t did, oapv_bitb_t *bitb, oapv_imgb_t *imgb, oapvd_stat_t *stat, int num_part_tiles, const int *part_tile_idxs)
+int oapvd_decode_frame(oapvd_t did, oapv_bitb_t *bitb, oapv_imgb_t *imgb, oapvd_stat_t *stat)
 {
     oapvd_ctx_t *ctx;
     oapv_pbuh_t  pbuh;
@@ -2673,8 +2658,6 @@ int oapvd_decode_frame(oapvd_t did, oapv_bitb_t *bitb, oapv_imgb_t *imgb, oapvd_
     oapv_assert_rv(ctx, OAPV_ERR_INVALID_ARGUMENT);
     oapv_assert_rv(bitb != NULL && bitb->addr != NULL, OAPV_ERR_INVALID_ARGUMENT);
     oapv_assert_rv(imgb != NULL && stat != NULL, OAPV_ERR_INVALID_ARGUMENT);
-    oapv_assert_rv(num_part_tiles >= 0, OAPV_ERR_INVALID_ARGUMENT);
-    oapv_assert_rv(num_part_tiles == 0 || part_tile_idxs != NULL, OAPV_ERR_INVALID_ARGUMENT);
     oapv_mset(stat, 0, sizeof(oapvd_stat_t));
 
     oapv_bs_t   *bs;
@@ -2696,7 +2679,7 @@ int oapvd_decode_frame(oapvd_t did, oapv_bitb_t *bitb, oapv_imgb_t *imgb, oapvd_
     oapv_assert_g(OAPV_SUCCEEDED(ret), ERR);
 
     // be ready to decode start
-    ret = dec_frm_prepare(ctx, num_part_tiles, part_tile_idxs, imgb);
+    ret = dec_frm_prepare(ctx, imgb);
     oapv_assert_g(OAPV_SUCCEEDED(ret), ERR);
 
     int           thread_ret;
@@ -2704,13 +2687,7 @@ int oapvd_decode_frame(oapvd_t did, oapv_bitb_t *bitb, oapv_imgb_t *imgb, oapvd_
     int           parallel_task = 1;
     int           tidx = 0;
 
-    if(num_part_tiles > 0) {
-        oapv_assert_gv(num_part_tiles <= ctx->num_tiles, ret, OAPV_ERR_INVALID_ARGUMENT, ERR);
-        parallel_task = (ctx->threads > num_part_tiles) ? num_part_tiles : ctx->threads;
-    }
-    else {
-        parallel_task = (ctx->threads > ctx->num_tiles) ? ctx->num_tiles : ctx->threads;
-    }
+    parallel_task = (ctx->threads > ctx->num_tiles) ? ctx->num_tiles : ctx->threads;
 
     /* decode tiles ************************************/
     for(tidx = 0; tidx < parallel_task - 1; tidx++) {

--- a/src/oapv_def.h
+++ b/src/oapv_def.h
@@ -347,21 +347,10 @@ struct oapve_ctx {
 #if ENABLE_DECODER
 ///////////////////////////////////////////////////////////////////////////////
 
-#define DEC_TILE_STAT_DECODE          (1 << 0)
-#define DEC_TILE_STAT_SKIP            (1 << 1)
-
-#define DEC_TILE_STAT_IS_DECODE(stat) ((stat) & DEC_TILE_STAT_DECODE)
-#define DEC_TILE_STAT_IS_SKIP(stat)   ((stat) & DEC_TILE_STAT_SKIP)
-
 #define DEC_TILE_STAT_FLAG_DO         (1 << 4)
 #define DEC_TILE_STAT_FLAG_ON         (1 << 5)
 #define DEC_TILE_STAT_FLAG_DONE       (1 << 6)
 #define DEC_TILE_STAT_FLAG_ERR        (1 << 7)
-
-#define DEC_TILE_STAT_DO(stat)        (((stat) & 0x0F) | DEC_TILE_STAT_FLAG_DO)
-#define DEC_TILE_STAT_ON(stat)        (((stat) & 0x0F) | DEC_TILE_STAT_FLAG_ON)
-#define DEC_TILE_STAT_DONE(stat)      (((stat) & 0x0F) | DEC_TILE_STAT_FLAG_DONE)
-#define DEC_TILE_STAT_ERR(stat)       (((stat) & 0x0F) | DEC_TILE_STAT_FLAG_ERR)
 
 #define DEC_TILE_STAT_IS_DO(stat)     ((stat) & DEC_TILE_STAT_FLAG_DO)
 #define DEC_TILE_STAT_IS_ON(stat)     ((stat) & DEC_TILE_STAT_FLAG_ON)


### PR DESCRIPTION
`oapvd_decode_tiles()` (#275) decodes a chosen set of tiles, so the tile
subset `oapvd_decode_frame()` took is no longer needed. Its
`num_part_tiles` / `part_tile_idxs` arguments are removed, along with the
now-dead decode/skip half of the per-tile status. The decoder app and the
programmer's guide are updated to match.

@jsperrier1 Carrying two APIs that do the same thing is not good, and I
would like tile decoding to be supported by a single API. This does remove
arguments from an exported function, so it breaks API and ABI. Is that
acceptable?
